### PR TITLE
Support UDP payloads and handlers

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -746,6 +746,24 @@ module Socket
   end
 
   #
+  # Returns peer information (host + port) in host:port format.
+  #
+  def peerinfo
+    if (pi = getpeername_as_array)
+      return pi[1] + ':' + pi[2].to_s
+    end 
+  end 
+
+  #
+  # Returns local information (host + port) in host:port format.
+  #
+  def localinfo
+    if (pi = getlocalname)
+      return pi[1] + ':' + pi[2].to_s
+    end 
+  end 
+
+  #
   # Returns a string that indicates the type of the socket, such as 'tcp'.
   #
   def type?

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -128,14 +128,14 @@ class Rex::Socket::Comm::Local
         usev6 = true
       end
 
-      # Force IPv6 mode for non-connected UDP sockets
-      if (type == ::Socket::SOCK_DGRAM and not param.peerhost)
-        # FreeBSD allows IPv6 socket creation, but throws an error on sendto()
-        # Windows 7 SP1 and newer also fail to sendto with IPv6 udp sockets
-        unless Rex::Compat.is_freebsd or Rex::Compat.is_windows
-          usev6 = true
-        end
-      end
+    #  # Force IPv6 mode for non-connected UDP sockets
+    #  if (type == ::Socket::SOCK_DGRAM and not param.peerhost)
+    #    # FreeBSD allows IPv6 socket creation, but throws an error on sendto()
+    #    # Windows 7 SP1 and newer also fail to sendto with IPv6 udp sockets
+    #    unless Rex::Compat.is_freebsd or Rex::Compat.is_windows
+    #      usev6 = true
+    #    end
+    #  end
 
       local = Rex::Socket.resolv_nbo(param.localhost) if param.localhost
       peer  = Rex::Socket.resolv_nbo(param.peerhost) if param.peerhost

--- a/lib/rex/socket/tcp.rb
+++ b/lib/rex/socket/tcp.rb
@@ -53,24 +53,6 @@ module Rex::Socket::Tcp
     end
   end
 
-  #
-  # Returns peer information (host + port) in host:port format.
-  #
-  def peerinfo
-    if (pi = getpeername_as_array)
-      return pi[1] + ':' + pi[2].to_s
-    end
-  end
-
-  #
-  # Returns local information (host + port) in host:port format.
-  #
-  def localinfo
-    if (pi = getlocalname)
-      return pi[1] + ':' + pi[2].to_s
-    end
-  end
-
   # returns socket type
   def type?
     return 'tcp'


### PR DESCRIPTION
With the addition of UDP sessions, this information needs to be
available to both L4 consumers. Technically speaking, socket.rb
can present an L3-only construct (raw IP sockets), which wont have
port information. However, this has not been an issue when using
the new transports in testing.

This is a breakout of the UDP handlers and payloads PR (#6035).