### PR TITLE
Change proxy chain delimiter from hyphen to comma

### DIFF
--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -149,7 +149,7 @@ class Rex::Socket::Parameters
     end
 
     if hash['Proxies']
-      self.proxies = hash['Proxies'].split('-').map{|a| a.strip}.map{|a| a.split(':').map{|b| b.strip}}
+      self.proxies = hash['Proxies'].split(',').map{|a| a.strip}.map{|a| a.split(':').map{|b| b.strip}}
     end
 
     # The protocol this socket will be using


### PR DESCRIPTION
Everyone seems to think it's a comma. It's been hyphen for 12 years.

https://github.com/rapid7/metasploit-framework/pull/4606
http://cs.uccs.edu/~cs591/metasploit/users_guide3_1.pdf