### PR TITLE
Fix bug on `sport` packing

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -348,7 +348,7 @@ class Rex::Socket::Comm::Local
       num_rest_nodes = 1
 
       _af, shost, sport = sock.getpeername_as_array
-      first_route_item = [shost, 0, sport, 0, 0].pack("A*CA*cc")
+      first_route_item = [shost, 0, sport.to_s, 0, 0].pack("A*CA*cc")
       route_data = [first_route_item.length, first_route_item].pack("NA*")
       route_data << [host, 0, port.to_s, 0, 0].pack("A*CA*cc")
 


### PR DESCRIPTION
## How to reproduce the bug:
--------------------------------------
```
metasploit > use auxiliary/scanner/sap/sap_mgmt_con_version
metasploit auxiliary(sap_mgmt_con_version) > set Proxies sapni:192.168.1.220:3299
Proxies => sapni:192.168.1.220:3299
metasploit auxiliary(sap_mgmt_con_version) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
metasploit auxiliary(sap_mgmt_con_version) > exploit

[*] [2017.03.16-22:06:31] Error: 127.0.0.1: TypeError no implicit conversion of Fixnum into String
[*] [2017.03.16-22:06:31] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```