### PR TITLE
Upstream client SSL configuration for Rex sockets

### DIFF
--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -148,6 +148,22 @@ class Rex::Socket::Parameters
       end
     end
 
+    if (hash['SSLClientCert'] and ::File.file?(hash['SSLClientCert']))
+      begin
+        self.ssl_client_cert = ::File.read(hash['SSLClientCert'])
+      rescue ::Exception => e
+        elog("Failed to read client cert: #{e.class}: #{e}", LogSource)
+      end
+    end
+
+    if (hash['SSLClientKey'] and ::File.file?(hash['SSLClientKey']))
+      begin
+        self.ssl_client_key = ::File.read(hash['SSLClientKey'])
+      rescue ::Exception => e
+        elog("Failed to read client key: #{e.class}: #{e}", LogSource)
+      end
+    end
+
     if hash['Proxies']
       self.proxies = hash['Proxies'].split(',').map{|a| a.strip}.map{|a| a.split(':').map{|b| b.strip}}
     end
@@ -353,10 +369,16 @@ class Rex::Socket::Parameters
   attr_accessor :ssl_compression
 
   #
-  # The SSL context verification mechanism
+  # The client SSL certificate
   #
+  attr_accessor :ssl_client_cert
+  #
+  # The client SSL key
+  #
+  attr_accessor :ssl_client_key
+  #
+  # SSL certificate verification mode for SSL context
   attr_accessor :ssl_verify_mode
-
   #
   # Whether we should use IPv6
   # @return [Bool]

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -37,7 +37,9 @@ begin
   end
 
   #
-  # Set the SSL flag to true and call the base class's create_param routine.
+  # Set the SSL flag to true,
+  # create placeholders for client certs,
+  # call the base class's create_param routine.
   #
   def self.create_param(param)
     param.ssl   = true
@@ -94,6 +96,16 @@ begin
   def initsock_with_ssl_version(params, version)
     # Build the SSL connection
     self.sslctx  = OpenSSL::SSL::SSLContext.new(version)
+
+    # Configure client certificate
+    if params and params.ssl_client_cert
+      self.sslctx.cert = OpenSSL::X509::Certificate.new(params.ssl_client_cert)
+    end
+
+    # Configure client key
+    if params and params.ssl_client_key
+      self.sslctx.key = OpenSSL::PKey::RSA.new(params.ssl_client_key)
+    end
 
     # Configure the SSL context
     # TODO: Allow the user to specify the verify mode callback
@@ -317,6 +329,20 @@ begin
   #
   def peer_cert_chain
     sslsock.peer_cert_chain if sslsock
+  end
+
+  #
+  # Access to client cert
+  #
+  def client_cert
+    sslsock.sslctx.cert if sslsock
+  end
+
+  #
+  # Access to client key
+  #
+  def client_key
+    sslsock.sslctx.key if sslsock
   end
 
   #


### PR DESCRIPTION
This is a rehash of a very old change which was likely dropped in
one of the abominable PRs which was not landed due to complexity,
breakage, or gross overreach of the PR's scope...

Add client configuration options for Rex Sockets to use client
certificates along with appropriate setters and getters during
Rex::Socket::TcpSsl configuration.

Testing:
  In fork context only, not used all too often, needs eyes on.