### PR TITLE
Extract and mixin cert ops from server module

### DIFF
--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 require 'rex/socket/x509_certificate'
 require 'timeout'
+require 'openssl'
 
 ###
 #
@@ -9,15 +10,6 @@ require 'timeout'
 #
 ###
 module Rex::Socket::Ssl
-
-  @@loaded_openssl = false
-
-  begin
-    require 'openssl'
-    @@loaded_openssl = true
-    require 'openssl/nonblock'
-  rescue ::Exception
-  end
 
   module CertProvider
 

--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -1,0 +1,148 @@
+# -*- coding: binary -*-
+require 'rex/socket/x509_certificate'
+require 'timeout'
+
+###
+#
+# This class provides methods for interacting with an SSL wrapped TCP server.  It
+# implements the StreamServer IO interface.
+#
+###
+module Rex::Socket::Ssl
+
+  @@loaded_openssl = false
+
+  begin
+    require 'openssl'
+    @@loaded_openssl = true
+    require 'openssl/nonblock'
+  rescue ::Exception
+  end
+
+  #
+  # Parse a certificate in unified PEM format that contains a private key and
+  # one or more certificates. The first certificate is the primary, while any
+  # additional certificates are treated as intermediary certificates. This emulates
+  # the behavior of web servers like nginx.
+  #
+  # @param [String] ssl_cert
+  # @return [String, String, Array]
+  def self.ssl_parse_pem(ssl_cert)
+    Rex::Socket::X509Certificate.parse_pem(ssl_cert)
+  end
+
+  #
+  # Shim for the ssl_parse_pem module method
+  #
+  def ssl_parse_pem(ssl_cert)
+    Rex::Socket::SslTcpServer.ssl_parse_pem(ssl_cert)
+  end
+
+  def self.ssl_generate_subject
+    st  = Rex::Text.rand_state
+    loc = Rex::Text.rand_name.capitalize
+    org = Rex::Text.rand_name.capitalize
+    cn  = Rex::Text.rand_hostname
+    "US/ST=#{st}/L=#{loc}/O=#{org}/CN=#{cn}"
+  end
+
+  def self.ssl_generate_issuer
+    org = Rex::Text.rand_name.capitalize
+    cn  = Rex::Text.rand_name.capitalize + " " + Rex::Text.rand_name.capitalize
+    "US/O=#{org}/CN=#{cn}"
+  end
+
+  #
+  # Generate a realistic-looking but obstensibly fake SSL
+  # certificate. This matches a typical "snakeoil" cert.
+  #
+  # @return [String, String, Array]
+  def self.ssl_generate_certificate
+    yr      = 24*3600*365
+    vf      = Time.at(Time.now.to_i - rand(yr * 3) - yr)
+    vt      = Time.at(vf.to_i + (rand(9)+1) * yr)
+    subject = ssl_generate_subject
+    issuer  = ssl_generate_issuer
+    key     = OpenSSL::PKey::RSA.new(2048){ }
+    cert    = OpenSSL::X509::Certificate.new
+    cert.version    = 2
+    cert.serial     = (rand(0xFFFFFFFF) << 32) + rand(0xFFFFFFFF)
+    cert.subject    = OpenSSL::X509::Name.new([["C", subject]])
+    cert.issuer     = OpenSSL::X509::Name.new([["C", issuer]])
+    cert.not_before = vf
+    cert.not_after  = vt
+    cert.public_key = key.public_key
+
+    ef = OpenSSL::X509::ExtensionFactory.new(nil,cert)
+    cert.extensions = [
+      ef.create_extension("basicConstraints","CA:FALSE")
+    ]
+    ef.issuer_certificate = cert
+
+    cert.sign(key, OpenSSL::Digest::SHA256.new)
+
+    [key, cert, nil]
+  end
+
+  #
+  # Shim for the ssl_generate_certificate module method
+  #
+  def ssl_generate_certificate
+    Rex::Socket::SslTcpServer.ssl_generate_certificate
+  end
+
+  #
+  # Create a new ssl context.  If +ssl_cert+ is not given, generates a new
+  # key and a leaf certificate with random values.
+  #
+  # @param [Rex::Socket::Parameters] params
+  # @return [::OpenSSL::SSL::SSLContext]
+  def makessl(params)
+
+    if params.ssl_cert
+      key, cert, chain = ssl_parse_pem(params.ssl_cert)
+    else
+      key, cert, chain = ssl_generate_certificate
+    end
+
+    ctx = OpenSSL::SSL::SSLContext.new()
+    ctx.key = key
+    ctx.cert = cert
+    ctx.extra_chain_cert = chain
+    ctx.options = 0
+
+    if params.ssl_cipher
+      ctx.ciphers = params.ssl_cipher
+    end
+
+    # Older versions of OpenSSL do not export the OP_NO_COMPRESSION symbol
+    if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
+      # enable/disable the SSL/TLS-level compression
+      if params.ssl_compression
+        ctx.options &= ~OpenSSL::SSL::OP_NO_COMPRESSION
+      else
+        ctx.options |= OpenSSL::SSL::OP_NO_COMPRESSION
+      end
+    end
+
+    ctx.session_id_context = Rex::Text.rand_text(16)
+
+    return ctx
+  end
+
+  #
+  # This flag determines whether to use the non-blocking openssl
+  # API calls when they are available. This is still buggy on
+  # Linux/Mac OS X, but is required on Windows
+  #
+  def allow_nonblock?(sock=self.sock)
+    avail = sock.respond_to?(:accept_nonblock)
+    if avail and Rex::Compat.is_windows
+      return true
+    end
+    false
+  end
+
+  attr_accessor :sslctx
+end
+

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'rex/socket'
+require 'openssl'
 ###
 #
 # This class provides methods for interacting with an SSL TCP client
@@ -9,15 +10,6 @@ require 'rex/socket'
 module Rex::Socket::SslTcp
 
 begin
-  @@loaded_openssl = false
-
-  begin
-    require 'openssl'
-    @@loaded_openssl = true
-    require 'openssl/nonblock'
-  rescue ::Exception
-  end
-
 
   include Rex::Socket::Tcp
 
@@ -31,7 +23,6 @@ begin
   # Creates an SSL TCP instance.
   #
   def self.create(hash = {})
-    raise RuntimeError, "No OpenSSL support" if not @@loaded_openssl
     hash['SSL'] = true
     self.create_param(Rex::Socket::Parameters.from_hash(hash))
   end

--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -40,7 +40,6 @@ module Rex::Socket::SslTcpServer
   end
 
   def initsock(params = nil)
-    raise RuntimeError, 'No OpenSSL support' unless @@loaded_openssl
 
     if params && params.sslctx && params.sslctx.kind_of?(OpenSSL::SSL::SSLContext)
       self.sslctx = params.sslctx

--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -1,9 +1,8 @@
 # -*- coding: binary -*-
 require 'rex/socket'
+require 'rex/socket/ssl'
 require 'rex/socket/tcp_server'
 require 'rex/io/stream_server'
-require 'rex/socket/x509_certificate'
-require 'timeout'
 
 ###
 #
@@ -13,15 +12,7 @@ require 'timeout'
 ###
 module Rex::Socket::SslTcpServer
 
-  @@loaded_openssl = false
-
-  begin
-    require 'openssl'
-    @@loaded_openssl = true
-    require 'openssl/nonblock'
-  rescue ::Exception
-  end
-
+  include Rex::Socket::Ssl
   include Rex::Socket::TcpServer
 
   ##
@@ -114,130 +105,5 @@ module Rex::Socket::SslTcpServer
     end
   end
 
-  #
-  # Parse a certificate in unified PEM format that contains a private key and
-  # one or more certificates. The first certificate is the primary, while any
-  # additional certificates are treated as intermediary certificates. This emulates
-  # the behavior of web servers like nginx.
-  #
-  # @param [String] ssl_cert
-  # @return [String, String, Array]
-  def self.ssl_parse_pem(ssl_cert)
-    Rex::Socket::X509Certificate.parse_pem(ssl_cert)
-  end
-
-  #
-  # Shim for the ssl_parse_pem module method
-  #
-  def ssl_parse_pem(ssl_cert)
-    Rex::Socket::SslTcpServer.ssl_parse_pem(ssl_cert)
-  end
-
-  def self.ssl_generate_subject
-    st  = Rex::Text.rand_state
-    loc = Rex::Text.rand_name.capitalize
-    org = Rex::Text.rand_name.capitalize
-    cn  = Rex::Text.rand_hostname
-    "US/ST=#{st}/L=#{loc}/O=#{org}/CN=#{cn}"
-  end
-
-  def self.ssl_generate_issuer
-    org = Rex::Text.rand_name.capitalize
-    cn  = Rex::Text.rand_name.capitalize + " " + Rex::Text.rand_name.capitalize
-    "US/O=#{org}/CN=#{cn}"
-  end
-
-  #
-  # Generate a realistic-looking but obstensibly fake SSL
-  # certificate. This matches a typical "snakeoil" cert.
-  #
-  # @return [String, String, Array]
-  def self.ssl_generate_certificate
-    yr      = 24*3600*365
-    vf      = Time.at(Time.now.to_i - rand(yr * 3) - yr)
-    vt      = Time.at(vf.to_i + (rand(9)+1) * yr)
-    subject = ssl_generate_subject
-    issuer  = ssl_generate_issuer
-    key     = OpenSSL::PKey::RSA.new(2048){ }
-    cert    = OpenSSL::X509::Certificate.new
-    cert.version    = 2
-    cert.serial     = (rand(0xFFFFFFFF) << 32) + rand(0xFFFFFFFF)
-    cert.subject    = OpenSSL::X509::Name.new([["C", subject]])
-    cert.issuer     = OpenSSL::X509::Name.new([["C", issuer]])
-    cert.not_before = vf
-    cert.not_after  = vt
-    cert.public_key = key.public_key
-
-    ef = OpenSSL::X509::ExtensionFactory.new(nil,cert)
-    cert.extensions = [
-      ef.create_extension("basicConstraints","CA:FALSE")
-    ]
-    ef.issuer_certificate = cert
-
-    cert.sign(key, OpenSSL::Digest::SHA256.new)
-
-    [key, cert, nil]
-  end
-
-  #
-  # Shim for the ssl_generate_certificate module method
-  #
-  def ssl_generate_certificate
-    Rex::Socket::SslTcpServer.ssl_generate_certificate
-  end
-
-  #
-  # Create a new ssl context.  If +ssl_cert+ is not given, generates a new
-  # key and a leaf certificate with random values.
-  #
-  # @param [Rex::Socket::Parameters] params
-  # @return [::OpenSSL::SSL::SSLContext]
-  def makessl(params)
-
-    if params.ssl_cert
-      key, cert, chain = ssl_parse_pem(params.ssl_cert)
-    else
-      key, cert, chain = ssl_generate_certificate
-    end
-
-    ctx = OpenSSL::SSL::SSLContext.new()
-    ctx.key = key
-    ctx.cert = cert
-    ctx.extra_chain_cert = chain
-    ctx.options = 0
-
-    if params.ssl_cipher
-      ctx.ciphers = params.ssl_cipher
-    end
-
-    # Older versions of OpenSSL do not export the OP_NO_COMPRESSION symbol
-    if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
-      # enable/disable the SSL/TLS-level compression
-      if params.ssl_compression
-        ctx.options &= ~OpenSSL::SSL::OP_NO_COMPRESSION
-      else
-        ctx.options |= OpenSSL::SSL::OP_NO_COMPRESSION
-      end
-    end
-
-    ctx.session_id_context = Rex::Text.rand_text(16)
-
-    return ctx
-  end
-
-  #
-  # This flag determines whether to use the non-blocking openssl
-  # API calls when they are available. This is still buggy on
-  # Linux/Mac OS X, but is required on Windows
-  #
-  def allow_nonblock?(sock=self.sock)
-    avail = sock.respond_to?(:accept_nonblock)
-    if avail and Rex::Compat.is_windows
-      return true
-    end
-    false
-  end
-
-  attr_accessor :sslctx
 end
 


### PR DESCRIPTION
Generic SSL routines can be in their own module, for import by
consumers without having to drag the entire server infrastructure
in with it.

This pulls the certificate methods into Rex::Socket::Ssl for use
by consumers, and includes the module in Rex::Socket::SslTcpServer
as the initial consumer.