### PR TITLE
Improve SSL certificate generation

### DIFF
--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -18,13 +18,13 @@ module Rex::Socket::Ssl
       loc = Rex::Text.rand_name.capitalize
       org = Rex::Text.rand_name.capitalize
       cn  = Rex::Text.rand_hostname
-      "US/ST=#{st}/L=#{loc}/O=#{org}/CN=#{cn}"
+      "/C=US/ST=#{st}/L=#{loc}/O=#{org}/CN=#{cn}"
     end
 
     def self.ssl_generate_issuer
       org = Rex::Text.rand_name.capitalize
       cn  = Rex::Text.rand_name.capitalize + " " + Rex::Text.rand_name.capitalize
-      "US/O=#{org}/CN=#{cn}"
+      "/C=US/O=#{org}/CN=#{cn}"
     end
 
     #
@@ -42,8 +42,8 @@ module Rex::Socket::Ssl
       cert    = OpenSSL::X509::Certificate.new
       cert.version    = 2
       cert.serial     = (rand(0xFFFFFFFF) << 32) + rand(0xFFFFFFFF)
-      cert.subject    = OpenSSL::X509::Name.new([["C", subject]])
-      cert.issuer     = OpenSSL::X509::Name.new([["C", issuer]])
+      cert.subject    = OpenSSL::X509::Name.parse(subject)
+      cert.issuer     = OpenSSL::X509::Name.parse(issuer)
       cert.not_before = vf
       cert.not_after  = vt
       cert.public_key = key.public_key
@@ -162,4 +162,3 @@ module Rex::Socket::Ssl
 
   attr_accessor :sslctx
 end
-


### PR DESCRIPTION
SSL Certificate generation was not very clean 

See [this PR](https://github.com/rapid7/metasploit-framework/pull/9669) on the metasploit-framerwork repo 

## Verification 

- [ ] **Create** a test.rb file in the root directory of git repo 
```
#test.rb
$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)

require 'rex/text'
require 'rex/socket/ssl'

# Generating new SSL certificate
_, crt, _ = Rex::Socket::Ssl.ssl_generate_certificate()

# Print it to stdout
puts crt
```

- [ ] **Run** `ruby try.rb` 
- [ ] **Check** SSL Certificate validity using  [this](https://www.sslchecker.com/certdecoder) decoder