### PR TITLE
SSH socket registration removed

### DIFF
--- a/lib/rex/socket/ssh_factory.rb
+++ b/lib/rex/socket/ssh_factory.rb
@@ -38,7 +38,6 @@ module Rex
             'MsfExploit'   => msfmodule
           }
         )
-        msfmodule.add_socket(socket) if msfmodule
         socket
       end
     end


### PR DESCRIPTION
When using SSHFactory to create a socket to be used by net-ssh, that socket was registered, presumably for later cleanup.  The registration, however, was leading to premature socket closure and causing bad file descriptor errors downstream in an exploit that uses net-ssh.  This PR removes such registration.
