### PR TITLE
Update the range_walker to match better.

### DIFF
--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -76,7 +76,7 @@ class RangeWalker
   def parse(parseme)
     return nil if not parseme
     ranges = []
-    parseme.split(', ').map{ |a| a.split(' ') }.flatten.each do |arg|
+    parseme.split(',').map{ |a| a.split(' ') }.flatten.each do |arg|
       opts = {}
 
       # Handle IPv6 first (support ranges, but not CIDR)


### PR DESCRIPTION
For now, the `range_walker` did not support for the format like `8.8.8.8/24,1.1.1.1`

```
msf5 exploit(multi/http/apache_jetspeed_file_upload) > set rhosts 8.8.8.8/24,1.1.1.1
rhosts => 8.8.8.8/24,1.1.1.1
msf5 exploit(multi/http/apache_jetspeed_file_upload) > run

[-] Exploit failed: The following options failed to validate: RHOSTS.
[*] Exploit completed, but no session was created.
```

So I update it to support both `8.8.8.8/24,1.1.1.1` and `8.8.8.8/24, 1.1.1.1`. 