### PR TITLE
ensure socket is closed in source_address

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -602,12 +602,13 @@ module Socket
         'Comm'     => comm
       )
       r = s.getsockname[1]
-      s.close
 
       # Trim off the trailing interface ID for link-local IPv6
       return r.split('%').first
     rescue ::Exception
       return '127.0.0.1'
+    ensure
+      s.close if s
     end
   end
 


### PR DESCRIPTION
See https://github.com/rapid7/metasploit-framework/pull/11392/files, this moves the socket close into an ensure block so we cannot leak a socket if there is a failure here.

