### PR TITLE
Bring RangeWalker to IPv6 land

### DIFF
--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -97,8 +97,9 @@ class RangeWalker
 
         addr1, scope_id = addrs[0].split('%')
         opts[:scope_id] = scope_id if scope_id
+        opts[:ipv6] = true
 
-        addr2, scope_id = addrs[0].split('%')
+        addr2, scope_id = addrs[1].split('%')
         ( opts[:scope_id] ||= scope_id ) if scope_id
 
         # Both have to be IPv6 for this to work

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -81,7 +81,7 @@ class RangeWalker
 
       # Handle IPv6 CIDR first
       if arg.include?(':') && arg.include?('/')
-        return false if !valid_cidr_chars(arg)
+        return false if !valid_cidr_chars?(arg)
 
         ip_part,mask_part = arg.split("/")
         return false unless (0..128).include? mask_part.to_i
@@ -128,7 +128,7 @@ class RangeWalker
       # Handle IPv4 CIDR
       elsif arg.include?("/")
         # Then it's CIDR notation and needs special case
-        return false if !valid_cidr_chars(arg)
+        return false if !valid_cidr_chars?(arg)
         ip_part,mask_part = arg.split("/")
         return false unless (0..32).include? mask_part.to_i
         if ip_part =~ /^\d{1,3}(\.\d{1,3}){1,3}$/
@@ -430,11 +430,11 @@ class RangeWalker
 
   protected
 
-  def valid_cidr_chars(arg)
+  def valid_cidr_chars?(arg)
     return false if arg.include? ',-' # Improper CIDR notation (can't mix with 1,3 or 1-3 style IP ranges)
     return false if arg.scan("/").size > 1 # ..but there are too many slashes
-    ip_part,mask_part = arg.split("/")
-    return false if ip_part.nil? or ip_part.empty? or mask_part.nil? or mask_part.empty?
+    ip_part, mask_part = arg.split("/")
+    return false if ip_part.nil? || ip_part.empty? || mask_part.nil? || mask_part.empty?
     return false if mask_part !~ /^[0-9]{1,3}$/ # Illegal mask -- numerals only
     true
   end

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -79,8 +79,21 @@ class RangeWalker
     parseme.split(', ').map{ |a| a.split(' ') }.flatten.each do |arg|
       opts = {}
 
-      # Handle IPv6 first (support ranges, but not CIDR)
-      if arg.include?(":")
+      # Handle IPv6 CIDR first
+      if arg.include?(':') && arg.include?('/')
+        return false if !valid_cidr_chars(arg)
+
+        ip_part,mask_part = arg.split("/")
+        return false unless (0..128).include? mask_part.to_i
+
+        addr, scope_id = ip_part.split('%')
+        return false unless Rex::Socket.is_ipv6?(addr)
+
+        range = expand_cidr(addr + '/' + mask_part)
+        range.options[:scope_id] = scope_id if scope_id
+        ranges.push(range)
+      # Handle plain IPv6 next (support ranges, but not CIDR)
+      elsif arg.include?(':')
         addrs = arg.split('-', 2)
 
         # Handle a single address
@@ -115,12 +128,9 @@ class RangeWalker
       # Handle IPv4 CIDR
       elsif arg.include?("/")
         # Then it's CIDR notation and needs special case
-        return false if arg =~ /[,-]/ # Improper CIDR notation (can't mix with 1,3 or 1-3 style IP ranges)
-        return false if arg.scan("/").size > 1 # ..but there are too many slashes
+        return false if !valid_cidr_chars(arg)
         ip_part,mask_part = arg.split("/")
-        return false if ip_part.nil? or ip_part.empty? or mask_part.nil? or mask_part.empty?
-        return false if mask_part !~ /^[0-9]{1,2}$/ # Illegal mask -- numerals only
-        return false if mask_part.to_i > 32 # This too -- between 0 and 32.
+        return false unless (0..32).include? mask_part.to_i
         if ip_part =~ /^\d{1,3}(\.\d{1,3}){1,3}$/
           return false unless ip_part =~ Rex::Socket::MATCH_IPV4
         end
@@ -416,6 +426,17 @@ class RangeWalker
     rng.stop = addrs[addrs.length - 1]
     ranges.push(rng.dup)
     return ranges
+  end
+
+  protected
+
+  def valid_cidr_chars(arg)
+    return false if arg.include? ',-' # Improper CIDR notation (can't mix with 1,3 or 1-3 style IP ranges)
+    return false if arg.scan("/").size > 1 # ..but there are too many slashes
+    ip_part,mask_part = arg.split("/")
+    return false if ip_part.nil? or ip_part.empty? or mask_part.nil? or mask_part.empty?
+    return false if mask_part !~ /^[0-9]{1,3}$/ # Illegal mask -- numerals only
+    true
   end
 
 end

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -83,7 +83,7 @@ class RangeWalker
       if arg.include?(':') && arg.include?('/')
         return false if !valid_cidr_chars?(arg)
 
-        ip_part,mask_part = arg.split("/")
+        ip_part, mask_part = arg.split("/")
         return false unless (0..128).include? mask_part.to_i
 
         addr, scope_id = ip_part.split('%')
@@ -129,7 +129,7 @@ class RangeWalker
       elsif arg.include?("/")
         # Then it's CIDR notation and needs special case
         return false if !valid_cidr_chars?(arg)
-        ip_part,mask_part = arg.split("/")
+        ip_part, mask_part = arg.split("/")
         return false unless (0..32).include? mask_part.to_i
         if ip_part =~ /^\d{1,3}(\.\d{1,3}){1,3}$/
           return false unless ip_part =~ Rex::Socket::MATCH_IPV4

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe Rex::Socket::RangeWalker do
       expect(walker.next).to eq "::1"
     end
 
+    it "should handle IPv6 CIDR ranges" do
+      walker = Rex::Socket::RangeWalker.new("::1/127")
+      expect(walker).to be_valid
+      expect(walker.length).to eq 2
+      expect(walker.next).to eq "::"
+    end
+
+    it "should handle IPv6 CIDR ranges with a scope" do
+      walker = Rex::Socket::RangeWalker.new("::1%lo/127")
+      expect(walker).to be_valid
+      expect(walker.length).to eq 2
+      expect(walker.next).to eq "::%lo"
+    end
+
     context "with mulitple ranges" do
       let(:args) { "1.1.1.1-2 2.1-2.2.2 3.1-2.1-2.1 " }
       it { is_expected.to be_valid }

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe Rex::Socket::RangeWalker do
       expect(walker.next).to eq "10.1.1.1"
     end
 
+    it "should handle longform IPv6 ranges" do
+      walker = Rex::Socket::RangeWalker.new("::1-::2")
+      expect(walker).to be_valid
+      expect(walker.length).to eq 2
+      expect(walker.next).to eq "::1"
+    end
+
     context "with mulitple ranges" do
       let(:args) { "1.1.1.1-2 2.1-2.2.2 3.1-2.1-2.1 " }
       it { is_expected.to be_valid }


### PR DESCRIPTION
Adds CIDR (new) and range (broke in 2011) support to IPv6 ranges.

Verification
========

- [x] `rake spec` should pass
- [x] `ruby bin/console`
- [x] `Rex::Socket::RangeWalker.new` should work with:
  - [x] Ranges like `'fe80::3330-fe80::00ab:f000'`
  - [x] And CIDRs like `'fe80::/16'`
  - [x] And stuff with scopes like `'fe80::%eth0/100'`