### PR TITLE
Set certificate hostname from params

### DIFF
--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -140,6 +140,14 @@ class Rex::Socket::Parameters
       self.ssl_cipher = hash['SSLCipher']
     end
 
+    if (hash['VHOST'])
+      self.ssl_cn = hash['VHOST']
+    end
+
+    if (hash['SSLCommonName'])
+      self.ssl_cn = hash['SSLCommonName']
+    end
+
     if (hash['SSLCert'] and ::File.file?(hash['SSLCert']))
       begin
         self.ssl_cert = ::File.read(hash['SSLCert'])
@@ -358,6 +366,10 @@ class Rex::Socket::Parameters
   # ["DHE-RSA-AES256-SHA", "DHE-DSS-AES256-SHA"]
   # @return [String,Array]
   attr_accessor :ssl_cipher
+
+  # Which Common Name to use for certificate
+  # @return [String}
+  attr_accessor :ssl_cn
 
   # The SSL certificate, in pem format, stored as a string.  See
   # {Rex::Socket::SslTcpServer#makessl}

--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -13,12 +13,10 @@ module Rex::Socket::Ssl
 
   module CertProvider
 
-    def self.ssl_generate_subject
+    def self.ssl_generate_subject(cn = Rex::Text.rand_hostname, org = Rex::Text.rand_name)
       st  = Rex::Text.rand_state
       loc = Rex::Text.rand_name.capitalize
-      org = Rex::Text.rand_name.capitalize
-      cn  = Rex::Text.rand_hostname
-      "/C=US/ST=#{st}/L=#{loc}/O=#{org}/CN=#{cn}"
+      "/C=US/ST=#{st}/L=#{loc}/O=#{org.capitalize}/CN=#{cn}"
     end
 
     def self.ssl_generate_issuer
@@ -32,11 +30,11 @@ module Rex::Socket::Ssl
     # certificate. This matches a typical "snakeoil" cert.
     #
     # @return [String, String, Array]
-    def self.ssl_generate_certificate
+    def self.ssl_generate_certificate(cn = Rex::Text.rand_hostname, org = Rex::Text.rand_name)
       yr      = 24*3600*365
       vf      = Time.at(Time.now.to_i - rand(yr * 3) - yr)
       vt      = Time.at(vf.to_i + (rand(9)+1) * yr)
-      subject = ssl_generate_subject
+      subject = ssl_generate_subject(cn, org)
       issuer  = ssl_generate_issuer
       key     = OpenSSL::PKey::RSA.new(2048){ }
       cert    = OpenSSL::X509::Certificate.new
@@ -119,7 +117,7 @@ module Rex::Socket::Ssl
     if params.ssl_cert
       key, cert, chain = ssl_parse_pem(params.ssl_cert)
     else
-      key, cert, chain = ssl_generate_certificate
+      key, cert, chain = ssl_generate_certificate(params.ssl_cn)
     end
 
     ctx = OpenSSL::SSL::SSLContext.new()


### PR DESCRIPTION
This should help a bit with making the certificate common name match the VHOST or explicit SSLCommonName param passed down from Msf.
Not tested yet, needed for CONNECT->TLS MITM in the HTTP proxy (i think), should be useful in other spots too.