### PR TITLE
Fix ssl_generate_certificate to not generate expired certs - Fix #20

### DIFF
--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -35,7 +35,7 @@ module Rex::Socket::Ssl
     def self.ssl_generate_certificate(cert_vars: {}, **opts)
       yr      = 24*3600*365
       vf      = Time.at(Time.now.to_i - rand(yr * 3) - yr)
-      vt      = Time.at(vf.to_i + (rand(9)+1) * yr)
+      vt      = Time.at(vf.to_i + (rand(4..9) * yr))
       subject = ssl_generate_subject(**cert_vars)
       issuer  = ssl_generate_issuer
       key     = OpenSSL::PKey::RSA.new(2048){ }


### PR DESCRIPTION
```
msf5 > pry
[*] Starting Pry shell...
[*] You are in the "framework" object

[1] pry(#<Msf::Framework>)> yr      = 24*3600*365      
=> 31536000
[2] pry(#<Msf::Framework>)> vf      = Time.at(Time.now.to_i - rand(yr * 3) - yr)      
=> 2016-08-03 15:20:03 -0400
[3] pry(#<Msf::Framework>)> puts Time.at(vf)  
2016-08-03 15:20:03 -0400
=> nil
[4] pry(#<Msf::Framework>)> 100_000.times do      
[4] pry(#<Msf::Framework>)*   vt      = Time.at(vf.to_i + (rand(4..9) * yr))        
[4] pry(#<Msf::Framework>)*   if Time.at(vt) < Time.now    
[4] pry(#<Msf::Framework>)*     puts Time.at(vt)  
[4] pry(#<Msf::Framework>)*     raise HALT_AND_CATCH_FIRE   
[4] pry(#<Msf::Framework>)*   end  
[4] pry(#<Msf::Framework>)* end    
=> 100000
[5] pry(#<Msf::Framework>)> 
```

It might have been cleaner to base the expiry date on `Time.now`, rather than the creation date `vf`, but whatever.
