### PR TITLE
Add to_ and merge_ hash methods to the Parameters class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ group: stable
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.2
+  - 2.6.5

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -329,15 +329,16 @@ class Rex::Socket::Parameters
   def comm
     return @comm unless @comm.nil?
 
+    best_comm = nil
     # If no comm was explicitly specified, try to use the comm that is best fit
     # to handle the provided host based on the current routing table.
     if server and localhost
-      return Rex::Socket::SwitchBoard.best_comm(localhost)
+      best_comm = Rex::Socket::SwitchBoard.best_comm(localhost)
     elsif peerhost
-      return Rex::Socket::SwitchBoard.best_comm(peerhost)
+      best_comm =  Rex::Socket::SwitchBoard.best_comm(peerhost)
     end
 
-    Rex::Socket::Comm::Local
+    best_comm || Rex::Socket::Comm::Local
   end
 
   # The context hash that was passed in to the structure.  (default: {})

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -154,6 +154,8 @@ class Rex::Socket::Parameters
       rescue ::Exception => e
         elog("Failed to read cert: #{e.class}: #{e}", LogSource)
       end
+    elsif hash['SSLCertRaw']
+      self.ssl_cert = hash['SSLCertRaw']
     end
 
     if (hash['SSLClientCert'] and ::File.file?(hash['SSLClientCert']))
@@ -162,6 +164,8 @@ class Rex::Socket::Parameters
       rescue ::Exception => e
         elog("Failed to read client cert: #{e.class}: #{e}", LogSource)
       end
+    elsif hash['SSLClientCertRaw']
+      self.ssl_client_cert = hash['SSLClientCertRaw']
     end
 
     if (hash['SSLClientKey'] and ::File.file?(hash['SSLClientKey']))
@@ -170,6 +174,8 @@ class Rex::Socket::Parameters
       rescue ::Exception => e
         elog("Failed to read client key: #{e.class}: #{e}", LogSource)
       end
+    elsif hash['SSLClientKeyRaw']
+      self.ssl_client_key = hash['SSLClientKeyRaw']
     end
 
     if hash['Proxies']
@@ -229,6 +235,41 @@ class Rex::Socket::Parameters
 
     # Whether to force IPv6 addressing
     self.v6        = hash['IPv6'] || false
+  end
+
+  def to_hash
+    settings = {}
+    settings['PeerHost'] = self.peerhost unless self.peerhost.nil?
+    settings['LocalHost'] = self.localhost
+    settings['PeerPort'] = self.peerport
+    settings['LocalPort'] = self.localport
+    settings['Bare'] = self.bare
+
+    settings['SSL'] = self.ssl
+    settings['SSLContext'] = self.sslctx unless self.sslctx.nil?
+    settings['SSLVersion'] = self.ssl_version unless self.ssl_version.nil?
+    settings['SSLVerifyMode'] = self.ssl_verify_mode unless self.ssl_verify_mode.nil?
+    settings['SSLCompression'] = self.ssl_compression unless self.ssl_compression.nil?
+    settings['SSLCipher'] = self.ssl_cipher unless self.ssl_cipher.nil?
+    settings['SSLCommonName'] = self.ssl_cn unless self.ssl_cn.nil?
+    settings['SSLCertRaw'] = self.ssl_cert unless self.ssl_cert.nil?
+    settings['SSLClientCertRaw'] = self.ssl_client_cert unless self.ssl_client_cert.nil?
+    settings['SSLClientKeyRaw'] = self.ssl_client_key unless self.ssl_client_key.nil?
+
+    settings['Proxies'] = self.proxies.map{|a| a.join(':')}.join(',') unless self.proxies.nil?
+    settings['Proto'] = self.proto
+    settings['Server'] = self.server
+    settings['Comm'] = self.comm
+    settings['Context'] = self.context
+    settings['Retries'] = self.retries
+    settings['Timeout'] = self.timeout
+    settings['IPv6'] = self.v6
+
+    settings
+  end
+
+  def merge_hash(other_hash)
+    self.class.from_hash(to_hash.merge(other_hash))
   end
 
   ##
@@ -403,4 +444,5 @@ class Rex::Socket::Parameters
 
   alias peeraddr  peerhost
   alias localaddr localhost
+  alias to_h      to_hash
 end

--- a/spec/rex/socket/parameters_spec.rb
+++ b/spec/rex/socket/parameters_spec.rb
@@ -1,0 +1,62 @@
+# -*- coding:binary -*-
+require 'rex/socket/parameters'
+
+RSpec.describe Rex::Socket::Parameters do
+
+  let(:args) { { } }
+  subject(:params) { described_class.new(args) }
+
+  it { is_expected.to respond_to(:localhost) }
+  it { is_expected.to respond_to(:localport) }
+  it { is_expected.to respond_to(:client?) }
+  it { is_expected.to respond_to(:server?) }
+  it { is_expected.to respond_to(:ssl?) }
+  it { is_expected.to respond_to(:v6?) }
+
+  describe '.new' do
+
+    it "should handle an IPv4 local host definition" do
+      params = Rex::Socket::Parameters.new({ "LocalHost" => "1.2.3.4", "LocalPort" => 1234 })
+      expect(params.localhost).to eq ("1.2.3.4")
+      expect(params.localport).to eq 1234
+      expect(params.v6?).to eq false
+    end
+
+    it "should handle an IPv6 local host definition" do
+      params = Rex::Socket::Parameters.new({ "LocalHost" => "::1", "LocalPort" => 1234, "IPv6" => true })
+      expect(params.localhost).to eq ("::1")
+      expect(params.localport).to eq 1234
+      expect(params.v6?).to eq true
+    end
+
+  end
+
+  describe '#merge_hash' do
+    it "should handle merging hash options" do
+      expect(params.localhost).to eq "0.0.0.0"
+      expect(params.localport).to eq 0
+      new_params = params.merge_hash({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 })
+      expect(new_params.localhost).to eq "5.6.7.8"
+      expect(new_params.localport).to eq 5678
+    end
+
+    it "should handle new proxy definitions" do
+      expect(params.proxies).to eq nil
+      new_params = params.merge_hash({"Proxies" => "1.2.3.4:1234, 5.6.7.8:5678"})
+      expect(new_params.proxies).to eq [
+        ["1.2.3.4", "1234"],
+        ["5.6.7.8", "5678"]
+      ]
+    end
+  end
+
+  describe '#to_hash' do
+    it "should return a populated hash" do
+      params_hash = params.to_hash
+      expect(params_hash).to be_a(Hash)
+      expect(params_hash.length).to be > 0
+      expect(params_hash).to include("LocalHost", "LocalPort", "IPv6", "SSL", "Server")
+    end
+  end
+
+end

--- a/spec/rex/socket/parameters_spec.rb
+++ b/spec/rex/socket/parameters_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe Rex::Socket::Parameters do
 
   end
 
-  describe '#merge_hash' do
+  describe '#merge' do
     it "should handle merging hash options" do
       expect(params.localhost).to eq "0.0.0.0"
       expect(params.localport).to eq 0
-      new_params = params.merge_hash({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 })
+      new_params = params.merge({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 })
       expect(new_params.localhost).to eq "5.6.7.8"
       expect(new_params.localport).to eq 5678
     end
 
     it "should handle new proxy definitions" do
       expect(params.proxies).to eq nil
-      new_params = params.merge_hash({"Proxies" => "1.2.3.4:1234, 5.6.7.8:5678"})
+      new_params = params.merge({"Proxies" => "1.2.3.4:1234, 5.6.7.8:5678"})
       expect(new_params.proxies).to eq [
         ["1.2.3.4", "1234"],
         ["5.6.7.8", "5678"]
@@ -50,12 +50,13 @@ RSpec.describe Rex::Socket::Parameters do
     end
   end
 
-  describe '#to_hash' do
-    it "should return a populated hash" do
-      params_hash = params.to_hash
-      expect(params_hash).to be_a(Hash)
-      expect(params_hash.length).to be > 0
-      expect(params_hash).to include("LocalHost", "LocalPort", "IPv6", "SSL", "Server")
+  describe '#merge!' do
+    it "should handle merging hash options in place" do
+      expect(params.localhost).to eq "0.0.0.0"
+      expect(params.localport).to eq 0
+      params.merge!({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 })
+      expect(params.localhost).to eq "5.6.7.8"
+      expect(params.localport).to eq 5678
     end
   end
 

--- a/spec/rex/socket/parameters_spec.rb
+++ b/spec/rex/socket/parameters_spec.rb
@@ -32,10 +32,20 @@ RSpec.describe Rex::Socket::Parameters do
   end
 
   describe '#merge' do
+    it "should handle merging" do
+      new_params = params.merge(Rex::Socket::Parameters.new({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 }))
+      expect(params.localhost).to eq "0.0.0.0"
+      expect(params.localport).to eq 0
+      expect(new_params.localhost).to eq "5.6.7.8"
+      expect(new_params.localport).to eq 5678
+    end
+
     it "should handle merging hash options" do
       expect(params.localhost).to eq "0.0.0.0"
       expect(params.localport).to eq 0
       new_params = params.merge({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 })
+      expect(params.localhost).to eq "0.0.0.0"
+      expect(params.localport).to eq 0
       expect(new_params.localhost).to eq "5.6.7.8"
       expect(new_params.localport).to eq 5678
     end
@@ -43,6 +53,7 @@ RSpec.describe Rex::Socket::Parameters do
     it "should handle new proxy definitions" do
       expect(params.proxies).to eq nil
       new_params = params.merge({"Proxies" => "1.2.3.4:1234, 5.6.7.8:5678"})
+      expect(params.proxies).to eq nil
       expect(new_params.proxies).to eq [
         ["1.2.3.4", "1234"],
         ["5.6.7.8", "5678"]
@@ -51,10 +62,10 @@ RSpec.describe Rex::Socket::Parameters do
   end
 
   describe '#merge!' do
-    it "should handle merging hash options in place" do
+    it "should handle merging in place" do
       expect(params.localhost).to eq "0.0.0.0"
       expect(params.localport).to eq 0
-      params.merge!({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 })
+      params.merge!(Rex::Socket::Parameters.new({"LocalHost" => "5.6.7.8", "LocalPort" => 5678 }))
       expect(params.localhost).to eq "5.6.7.8"
       expect(params.localport).to eq 5678
     end


### PR DESCRIPTION
This PR adds two new methods (and some basic testing) to the `Rex::Socket::Parameters` class. The intention is to allow the class to be updated while leveraging the existing logic within the `#new` method. This will be used in a PR I'll be submitting soon to Metasploit to allow parameters to be updated with reported `LocalHost` and `LocalPort` settings for sockets that are determined by the OS (as is the case when `LocalPort` is `0` for example).

## Testing Steps
- [ ] Make sure the new rspec tests pass and look reasonable
- [ ] Check the new methods, something similar to the example below

## Example Usage
```
msf5 > irb
[*] Starting IRB shell...
[*] You are in the "framework" object

irb: warn: can't alias jobs from irb_jobs.
>> params = Rex::Socket::Parameters.new({})
=> #<Rex::Socket::Parameters:0x00007f8e284f1240 @peerhost=nil, @localhost="0.0.0.0", @peerport=0, @localport=0, @bare=false, @ssl=false, @proto="tcp", @server=false, @comm=Rex::Socket::Comm::Local, @context={}, @retries=0, @timeout=5, @v6=false>
>> params.to_hash
=> {"LocalHost"=>"0.0.0.0", "PeerPort"=>0, "LocalPort"=>0, "Bare"=>false, "SSL"=>false, "Proto"=>"tcp", "Server"=>false, "Comm"=>Rex::Socket::Comm::Local, "Context"=>{}, "Retries"=>0, "Timeout"=>5, "IPv6"=>false}
>> params.merge_hash({"LocalHost" => "127.0.0.1", "LocalPort" => 51738})
=> #<Rex::Socket::Parameters:0x00007f8e290d1f88 @peerhost=nil, @localhost="127.0.0.1", @peerport=0, @localport=51738, @bare=false, @ssl=false, @proto="tcp", @server=false, @comm=Rex::Socket::Comm::Local, @context={}, @retries=0, @timeout=5, @v6=false>
>> params.merge_hash({"LocalHost" => "127.0.0.1", "LocalPort" => 51738}).to_hash
=> {"LocalHost"=>"127.0.0.1", "PeerPort"=>0, "LocalPort"=>51738, "Bare"=>false, "SSL"=>false, "Proto"=>"tcp", "Server"=>false, "Comm"=>Rex::Socket::Comm::Local, "Context"=>{}, "Retries"=>0, "Timeout"=>5, "IPv6"=>false}
>> params.merge_hash({"LocalHost" => "127.0.0.1", "LocalPort" => 51738}).to_hash
```