### PR TITLE
Store the local name info on server client sockets

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -732,14 +732,19 @@ module Socket
   end
 
   #
-  # Wrapper around getsockname
+  # Wrapper around getsockname that stores the local address and local port values.
   #
   def getlocalname
-    getsockname
+    if self.localhost.nil? && self.localport.nil?
+      _, self.localhost, self.localport = getsockname
+    end
+
+    family = Socket.is_ipv4?(self.localhost) ? ::Socket::AF_INET : ::Socket::AF_INET6
+    [family, self.localhost, self.localport]
   end
 
   #
-  # Return peer connection information.
+  # Returns peer connection information as an array.
   #
   def getpeername_as_array
     peer_name = nil

--- a/lib/rex/socket/tcp_server.rb
+++ b/lib/rex/socket/tcp_server.rb
@@ -61,6 +61,11 @@ module  Rex::Socket::TcpServer
 
       t.peerhost = pn[1]
       t.peerport = pn[2]
+
+      ln = t.getlocalname
+
+      t.localhost = ln[1]
+      t.localport = ln[2]
     end
 
     t


### PR DESCRIPTION
This updates the `#getlocalname` function to store and return the local host and local port information. It's also explicitly set when the server accepts the connection which ensures that the information can be retrieved later for the purposes of logging. I opted to update the `#getlocalname` function and not the `#getsockname` function because:
* `#getlocalname` is used in fewer locations
* `#getsockname` adds additional information on a meterpreter socket via [SocketAbstraction](https://github.com/rapid7/metasploit-framework/blob/349051531a027f296c97363ab43f0441a31d0834/lib/rex/post/meterpreter/channels/socket_abstraction.rb#L24-L37)

This fixes issues where `#getlocalname` is called on sockets backed by Meterpreter sessions using the reverse HTTP(S) transports such as the Framework's `connect` command and the SOCKS5 server.

## Examples
All are using `windows/x64/meterpreter/reverse_http` as the Comm.

### Without The Patch
```
msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > connect -c -1 scanme.nmap.org 22
[-] Error while running command connect: closed stream

Call stack:
/home/smcintyre/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/rex-socket-0.1.22/lib/rex/socket.rb:731:in `getsockname'
/home/smcintyre/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/rex-socket-0.1.22/lib/rex/socket.rb:731:in `getsockname'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/channels/socket_abstraction.rb:33:in `getsockname'
/home/smcintyre/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/rex-socket-0.1.22/lib/rex/socket.rb:738:in `getlocalname'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:400:in `cmd_connect'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:158:in `run'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
```

```
  : metasploit-framework: 13:51:40 ~-msf curl -vvv --socks5 127.0.0.1:5000 http://104.131.39.224/
*   Trying 127.0.0.1:5000...
* TCP_NODELAY set
* SOCKS5 communication to 104.131.39.224:80
* SOCKS5 connect to IPv4 104.131.39.224 (locally resolved)
* Failed to receive SOCKS5 connect request ack.
* Closing connection 0
curl: (7) Failed to receive SOCKS5 connect request ack.
exit status: 7                                                                                                                                                                                                                                                                                                                                                            
  : metasploit-framework: 13:51:51 ~-msf tail -n2  ~/.msf4/logs/framework.log
[03/10/2020 13:51:46] [w(0)] core: Client.start - closed stream
[03/10/2020 13:51:46] [w(0)] core: monitor_rsock: the remote socket is nil, exiting loop
  : metasploit-framework: 13:52:14 ~-msf 
```

### With The Patch

```
msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > connect -c -1 scanme.nmap.org 22
[*] Connected to scanme.nmap.org:22 (via: 192.168.159.147:49640)
SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.13
^Cmsf5 exploit(windows/http/ssrs_navcorrector_viewstate) > 
```

```
  : metasploit-framework: 13:53:31 ~-msf curl -vvv --socks5 127.0.0.1:5000 http://104.131.39.224/
*   Trying 127.0.0.1:5000...
* TCP_NODELAY set
* SOCKS5 communication to 104.131.39.224:80
* SOCKS5 connect to IPv4 104.131.39.224 (locally resolved)
* SOCKS5 request granted.
* Connected to 127.0.0.1 (127.0.0.1) port 5000 (#0)
> GET / HTTP/1.1
> Host: 104.131.39.224
> User-Agent: curl/7.66.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.16.1
< Date: Tue, 10 Mar 2020 18:04:04 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: https://zerosteiner.com/
< Referrer-Policy: same-origin
< X-Content-Type-Options: nosniff
< X-Frame-Options: DENY
< X-Robots-Tag: none
< X-XSS-Protection: 1; mode=block
< 
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.16.1</center>
</body>
</html>
* Connection #0 to host 127.0.0.1 left intact
  : metasploit-framework: 14:04:18 ~-msf 
```