### PR TITLE
Add github actions for testing and some changes to support Ruby 3

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,57 @@
+name: Verify
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+        test_cmd:
+          - bundle exec rspec
+
+    env:
+      RAILS_ENV: test
+
+    name: Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Setup bundler
+        run: |
+          gem install bundler
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: ${{ matrix.test_cmd }}
+        run: |
+          echo "${CMD}"
+          bash -c "${CMD}"
+        env:
+          CMD: ${{ matrix.test_cmd }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-group: stable
-cache: bundler
-language: ruby
-rvm:
-  - 2.7.2

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rex-socket.gemspec
 gemspec
+gem 'pry', '~> 0.13.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rex-socket.gemspec
 gemspec
-gem 'pry', '~> 0.13.1'
+
+group :development do
+  gem 'pry-byebug'
+end

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -174,10 +174,9 @@ module Socket
   end
 
   #
-  # Wrapper for +::Socket.gethostbyname+ that takes special care to see if the
-  # supplied address is already an ASCII IP address.  This is necessary to
-  # prevent blocking while waiting on a DNS reverse lookup when we already
-  # have what we need.
+  # ::Addrinfo.getaddrinfo checks to see if the supplied address is already
+  # an ASCII IP address.  This is necessary to prevent blocking while waiting
+  # on a DNS reverse lookup when we already have what we need.
   #
   # @param hostname [String] A hostname or ASCII IP address
   # @return [Array<String>]
@@ -192,19 +191,6 @@ module Socket
       address_info.ip_address
     end
     return [] if not res
-
-    # Rubinius has a bug where gethostbyname returns dotted quads instead of
-    # NBO, but that's what we want anyway, so just short-circuit here.
-    if res[0] =~ MATCH_IPV4 || res[0] =~ MATCH_IPV6
-      unless accept_ipv6
-        res.reject!{ |ascii| ascii =~ MATCH_IPV6 }
-      end
-    else
-      unless accept_ipv6
-        res.reject!{ |nbo| nbo.length != 4 }
-      end
-      res.map!{ |nbo| self.addr_ntoa(nbo) }
-    end
 
     res
   end

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -110,7 +110,8 @@ RSpec.describe Rex::Socket do
 
   describe '.getaddresses' do
 
-    subject { described_class.getaddresses('whatever') }
+    let(:accepts_ipv6) { true }
+    subject { described_class.getaddresses('whatever', accepts_ipv6) }
 
     before(:example) do
       allow(Addrinfo).to receive(:getaddrinfo).and_return(response_addresses.map {|address| Addrinfo.ip(address)})
@@ -129,14 +130,26 @@ RSpec.describe Rex::Socket do
     end
 
     context 'when ::Addrinfo.getaddrinfo returns IPv6 responses' do
-      let(:response_afamily) { Socket::AF_INET6 }
-      let(:response_addresses) { ["fe80::1", "fe80::2"] }
+      context "when accepts_ipv6 is true" do
+        let(:accepts_ipv6) { true }
+        let(:response_afamily) { Socket::AF_INET6 }
+        let(:response_addresses) { ["fe80::1", "fe80::2"] }
 
-      it { is_expected.to be_an(Array) }
-      it { expect(subject.size).to eq(2) }
-      it "should return the ASCII addresses" do
-        expect(subject).to include("fe80::1")
-        expect(subject).to include("fe80::2")
+        it { is_expected.to be_an(Array) }
+        it { expect(subject.size).to eq(2) }
+        it "should return the ASCII addresses" do
+          expect(subject).to include("fe80::1")
+          expect(subject).to include("fe80::2")
+        end
+      end
+
+      context "when accepts_ipv6 is false" do
+        let(:accepts_ipv6) { false }
+        let(:response_afamily) { Socket::AF_INET6 }
+        let(:response_addresses) { ["fe80::1", "fe80::2"] }
+
+        it { is_expected.to be_an(Array) }
+        it { expect(subject).to be_empty }
       end
     end
   end

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Rex::Socket do
       allow(Addrinfo).to receive(:getaddrinfo).and_return(response_addresses.map {|address| Addrinfo.ip(address)})
     end
 
-    context "with rubinius' bug returning ASCII addresses" do
+    context 'when ::Addrinfo.getaddrinfo returns IPv4 responses' do
       let(:response_afamily) { Socket::AF_INET }
       let(:response_addresses) { ["1.1.1.1", "2.2.2.2"] }
 
@@ -95,7 +95,26 @@ RSpec.describe Rex::Socket do
       it "should return the first ASCII address" do
         expect(subject).to eq "1.1.1.1"
       end
+    end
 
+    context 'when ::Addrinfo.getaddrinfo returns IPv6 responses' do
+      let(:response_afamily) { Socket::AF_INET6 }
+      let(:response_addresses) { ["fe80::1", "fe80::2"] }
+
+      it { is_expected.to be_a(String) }
+      it "should return the first ASCII address" do
+        expect(subject).to eq "fe80::1"
+      end
+
+      context "with rubinius' bug returning ASCII addresses" do
+      let(:response_afamily) { Socket::AF_INET }
+      let(:response_addresses) { ["1.1.1.1", "2.2.2.2"] }
+
+      it { is_expected.to be_a(String) }
+      it "should return the first ASCII address" do
+        expect(subject).to eq "1.1.1.1"
+      end
+      end
     end
   end
 

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -84,27 +84,7 @@ RSpec.describe Rex::Socket do
     subject { described_class.getaddress('whatever') }
 
     before(:example) do
-      expect(Socket).to receive(:gethostbyname).and_return(['name', ['aliases'], response_afamily, *response_addresses])
-    end
-
-    context 'when ::Socket.gethostbyname returns IPv4 responses' do
-      let(:response_afamily) { Socket::AF_INET }
-      let(:response_addresses) { ["\x01\x01\x01\x01", "\x02\x02\x02\x02"] }
-
-      it { is_expected.to be_a(String) }
-      it "should return the first ASCII address" do
-        expect(subject).to eq "1.1.1.1"
-      end
-    end
-
-    context 'when ::Socket.gethostbyname returns IPv6 responses' do
-      let(:response_afamily) { Socket::AF_INET6 }
-      let(:response_addresses) { ["\xfe\x80"+("\x00"*13)+"\x01", "\xfe\x80"+("\x00"*13)+"\x02"] }
-
-      it { is_expected.to be_a(String) }
-      it "should return the first ASCII address" do
-        expect(subject).to eq "fe80::1"
-      end
+      allow(Addrinfo).to receive(:getaddrinfo).and_return(response_addresses.map {|address| Addrinfo.ip(address)})
     end
 
     context "with rubinius' bug returning ASCII addresses" do
@@ -124,34 +104,10 @@ RSpec.describe Rex::Socket do
     subject { described_class.getaddresses('whatever') }
 
     before(:example) do
-      expect(Socket).to receive(:gethostbyname).and_return(['name', ['aliases'], response_afamily, *response_addresses])
+      allow(Addrinfo).to receive(:getaddrinfo).and_return(response_addresses.map {|address| Addrinfo.ip(address)})
     end
 
-    context 'when ::Socket.gethostbyname returns IPv4 responses' do
-      let(:response_afamily) { Socket::AF_INET }
-      let(:response_addresses) { ["\x01\x01\x01\x01", "\x02\x02\x02\x02"] }
-
-      it { is_expected.to be_an(Array) }
-      it { expect(subject.size).to eq(2) }
-      it "should return the ASCII addresses" do
-        expect(subject).to include("1.1.1.1")
-        expect(subject).to include("2.2.2.2")
-      end
-    end
-
-    context 'when ::Socket.gethostbyname returns IPv6 responses' do
-      let(:response_afamily) { Socket::AF_INET6 }
-      let(:response_addresses) { ["\xfe\x80"+("\x00"*13)+"\x01", "\xfe\x80"+("\x00"*13)+"\x02"] }
-
-      it { is_expected.to be_an(Array) }
-      it { expect(subject.size).to eq(2) }
-      it "should return the ASCII addresses" do
-        expect(subject).to include("fe80::1")
-        expect(subject).to include("fe80::2")
-      end
-    end
-
-    context "with rubinius' bug returning ASCII addresses" do
+    context 'when ::Addrinfo.getaddrinfo returns IPv4 responses' do
       let(:response_afamily) { Socket::AF_INET }
       let(:response_addresses) { ["1.1.1.1", "2.2.2.2"] }
 
@@ -161,7 +117,18 @@ RSpec.describe Rex::Socket do
         expect(subject).to include("1.1.1.1")
         expect(subject).to include("2.2.2.2")
       end
+    end
 
+    context 'when ::Addrinfo.getaddrinfo returns IPv6 responses' do
+      let(:response_afamily) { Socket::AF_INET6 }
+      let(:response_addresses) { ["fe80::1", "fe80::2"] }
+
+      it { is_expected.to be_an(Array) }
+      it { expect(subject.size).to eq(2) }
+      it "should return the ASCII addresses" do
+        expect(subject).to include("fe80::1")
+        expect(subject).to include("fe80::2")
+      end
     end
   end
 

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -105,16 +105,6 @@ RSpec.describe Rex::Socket do
       it "should return the first ASCII address" do
         expect(subject).to eq "fe80::1"
       end
-
-      context "with rubinius' bug returning ASCII addresses" do
-      let(:response_afamily) { Socket::AF_INET }
-      let(:response_addresses) { ["1.1.1.1", "2.2.2.2"] }
-
-      it { is_expected.to be_a(String) }
-      it "should return the first ASCII address" do
-        expect(subject).to eq "1.1.1.1"
-      end
-      end
     end
   end
 


### PR DESCRIPTION
This PR adds some changes that were required to transition over to `Ruby 3`, as well as adding GitHub actions for testing.


Adding GitHub actions for testing:
![image](https://user-images.githubusercontent.com/69522014/107776109-15b9e580-6d39-11eb-9b40-74078c5819c8.png)

This PR fixes the following Ruby 3 deprecation warnings:
![image](https://user-images.githubusercontent.com/60357436/108225778-29e45500-7134-11eb-9f71-bc2eb3ebf73e.png)

## Note
Some tests were removed, the previous `::Socket.gethostbyname()` returned an array of information, which included the byte address associated with `host/hostname`. The new ::Addrinfo.getaddrinfo() now returns an array of addresses only.

Any other code that was dependant on `::Socket.gethostbyname()` returning the byte addresses has been changed to handle that with a separate method call. 

Ruby 3 upgrade ticket https://github.com/rapid7/metasploit-framework/issues/14666