### PR TITLE
RangeWalker Updates To Return Hostnames When Available

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -14,6 +14,8 @@ module Rex
 ###
 module Socket
 
+  LogSource = 'rex-socket'
+
   module Comm
   end
 
@@ -745,7 +747,7 @@ module Socket
       peer_name = Socket.from_sockaddr(self.getpeername)
     rescue ::Errno::EINVAL => e
       # Ruby's getpeername method may call rb_sys_fail("getpeername(2)")
-      elog("#{e.message} (#{e.class})#{e.backtrace * "\n"}\n", 'core', LEV_3)
+      elog("#{e.message} (#{e.class})#{e.backtrace * "\n"}\n", LogSource, LEV_3)
     end
 
     return peer_name

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -132,7 +132,7 @@ class RangeWalker
 
   # Returns the next host in the range.
   #
-  # @return [String] The next host in the range
+  # @return [Hash<Symbol, String>] The next host in the range
   def next_host
     return false if not valid?
 

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -216,7 +216,7 @@ class RangeWalker
   # {#next_ip}
   #
   # @return [self]
-  def each(&block)
+  def each_ip(&block)
     while (ip = next_ip)
       block.call(ip)
     end
@@ -225,7 +225,9 @@ class RangeWalker
     self
   end
 
-  def each_hash(&block)
+  alias each each_ip
+
+  def each_host(&block)
     while (host_hash = next_host)
       block.call(host_hash)
     end

--- a/lib/rex/socket/switch_board.rb
+++ b/lib/rex/socket/switch_board.rb
@@ -276,7 +276,7 @@ protected
   # Initializes the underlying stuff.
   #
   def _init
-    if (@_initialized != true)
+    unless @_initialized
       @_initialized = true
       self.routes   = Array.new
       self.mutex    = Mutex.new

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -4,8 +4,7 @@ require 'rex/socket/range_walker'
 RSpec.describe Rex::Socket::RangeWalker do
 
   let(:args) { "::1" }
-  let(:resolver) { nil }
-  subject(:walker) { described_class.new(args, resolver: resolver) }
+  subject(:walker) { described_class.new(args) }
 
   it { is_expected.to respond_to(:length) }
   it { is_expected.to respond_to(:valid?) }
@@ -27,15 +26,6 @@ RSpec.describe Rex::Socket::RangeWalker do
       let(:args) { "localhost/24" }
       it { is_expected.to be_valid }
       it { expect(subject.length).to eq(256) }
-    end
-
-    context "with a hostname and resolver" do
-      ip_address = "127.#{rand(1..255)}.#{rand(1..255)}.#{rand(1..255)}"
-      let(:args) { "localhost" }
-      let(:resolver) { -> hostname { [ ip_address ] } }
-      it { is_expected.to be_valid }
-      it { expect(subject.length).to eq(1) }
-      it { expect(subject.next).to eq(ip_address) }
     end
 
     context "with an invalid hostname" do

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe Rex::Socket::RangeWalker do
       let(:args) { "localhost" }
       it { is_expected.to be_valid }
       it { expect(subject.length).to be >= 1 }
-      let(:host) { subject.next_host }
-      it { expect(host).to have_key(:hostname) }
-      it { expect(host[:hostname]).to eq('localhost') }
-      it { expect(host).to have_key(:address) }
     end
 
     context "with a hostname and CIDR" do
@@ -172,15 +168,33 @@ RSpec.describe Rex::Socket::RangeWalker do
     end
   end
 
-  describe '#each' do
+  describe '#each_ip' do
     let(:args) { "10.1.1.1-2,2,3 10.2.2.2" }
 
     it "should yield all ips" do
       got = []
-      walker.each { |ip|
+      walker.each_ip { |ip|
         got.push ip
       }
       expect(got).to eq ["10.1.1.1", "10.1.1.2", "10.1.1.3", "10.2.2.2"]
+    end
+
+  end
+
+  describe '#each_host' do
+    let(:args) { "localhost" }
+
+    it "should yield a host" do
+      got = []
+      walker.each_host { |host|
+        got.push host
+      }
+      expect(got.length).to be > 0
+      host = got[0]
+      expect(host).to have_key(:hostname)
+      expect(host[:hostname]).to eq('localhost')
+      expect(host).to have_key(:address)
+      expect(Rex::Socket.is_ip_addr?(host[:address])).to be true
     end
 
   end


### PR DESCRIPTION
# Overview
This makes a couple of updates to the `Rex::Socket::RangeWalker` class. The main goal here is to keep the hostname to IP address information available for consumers of this API such as Metasploit.

Main changes include:
* `Rex::Socket::RangeWalker` changes
    * Refactored the _massive_ `#parse` function into smaller units
    * Added the `next_host` method to yield expanded information.

## Host hashes
This PR addresses a limitation that `RangeWalker` currently has. When hostnames are resolved to their IP address, the original hostname information is lost. This isn't a big deal when the caller only specifies one hostname, but if they specify say two hostnames that each resolve to one or more addresses, it becomes impossible for the caller to know which address is for which hostname. Knowing both the hostname and the address is important for protocols such HTTP where the hostname may need to be passed in the `VHOST` header or other cases where TLS is used and the hostname is required for validation. If the caller knows and specifies the hostname, it shouldn't be lost.

To address this the new `next_host` method is added. Instead of returning an IP address, it returns a hash containing information for targeting that host. When the IP address was obtained via a DNS lookup, that information will include a `hostname:` field with the original value.

Updated unit tests are included. By itself this is all dead code. Once landed however, Metasploit can be updated to leverage this within the RHOSTS processing to ensure that the `VHOST` is consistently set to the provided hostname field. This will improve handling multiple targets in HTTP modules.

## Edit
The original version of this PR included some SwitchBoard updates. I've removed those from the history since I think it makes more sense to keep these as separate changes. This set focuses on refactoring and updating RangeWalker. DNS resolution changes will be submitted as a separate unit.