### PR TITLE
Fix Some RangeWalker issues

### DIFF
--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -84,27 +84,27 @@ class RangeWalker
 
       # Handle IPv6 CIDR first
       if arg.include?(':') && arg.include?('/')
-        return false if (new_ranges = parse_ipv6_cidr(arg)).nil?
+        next if (new_ranges = parse_ipv6_cidr(arg)).nil?
 
       # Handle plain IPv6 next (support ranges, but not CIDR)
       elsif arg.include?(':')
-        return false if (new_ranges = parse_ipv6(arg)).nil?
+        next if (new_ranges = parse_ipv6(arg)).nil?
 
       # Handle IPv4 CIDR
       elsif arg.include?("/")
-        return false if (new_ranges = parse_ipv4_cidr(arg)).nil?
+        next if (new_ranges = parse_ipv4_cidr(arg)).nil?
 
       # Handle hostnames
       elsif arg =~ /[^-0-9,.*]/
-        return false if (new_ranges = parse_hostname(arg)).nil?
+        next if (new_ranges = parse_hostname(arg)).nil?
 
       # Handle IPv4 ranges
       elsif arg =~ MATCH_IPV4_RANGE
         # Then it's in the format of 1.2.3.4-5.6.7.8
-        return false if (new_ranges = parse_ipv4_ranges(arg)).nil?
+        next if (new_ranges = parse_ipv4_ranges(arg)).nil?
 
       else
-        return false if (new_ranges = expand_nmap(arg)).nil?
+        next if (new_ranges = expand_nmap(arg)).nil?
       end
 
       ranges += new_ranges

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -94,19 +94,42 @@ RSpec.describe Rex::Socket::RangeWalker do
       expect(walker).to include("10.1.3.5")
     end
 
-    it 'should reject CIDR ranges with missing octets' do
+    it 'should reject IPv4 CIDR ranges with missing octets' do
       walker = Rex::Socket::RangeWalker.new('192.168/24')
       expect(walker).not_to be_valid
     end
 
-    it 'should reject a CIDR range with too many octets' do
+    it 'should reject IPv6 CIDR ranges with missing octets' do
+      walker = Rex::Socket::RangeWalker.new(':1/24')
+      expect(walker).not_to be_valid
+    end
+
+    it 'should reject an IPv4 CIDR range with too many octets' do
       walker = Rex::Socket::RangeWalker.new('192.168.1.2.0/24')
+      expect(walker).not_to be_valid
+    end
+
+    it 'should reject an IPv6 CIDR range with too many octets' do
+      walker = Rex::Socket::RangeWalker.new('0:1:2:3:4:5:6:7:8/24')
       expect(walker).not_to be_valid
     end
 
     it 'should reject an IPv4 address with too many octets' do
       walker = Rex::Socket::RangeWalker.new('192.0.2.0.0')
       expect(walker).not_to be_valid
+
+      walker = Rex::Socket::RangeWalker.new('192.0.2.0.0 192.0.2.0')
+      expect(walker).to be_valid
+      expect(walker.length).to eq 1
+    end
+
+    it 'should reject an IPv6 address with too many octets' do
+      walker = Rex::Socket::RangeWalker.new('0:1:2:3:4:5:6:7:8')
+      expect(walker).not_to be_valid
+
+      walker = Rex::Socket::RangeWalker.new('0:1:2:3:4:5:6:7:8 0:1:2:3:4:5:6:7')
+      expect(walker).to be_valid
+      expect(walker.length).to eq 1
     end
 
     it "should default the lower bound of a range to 0" do

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Rex::Socket::RangeWalker do
       it { is_expected.to be_valid }
     end
 
-    it "should handle single ipv6 addresses" do
+    it "should handle single IPv6 addresses" do
       walker = Rex::Socket::RangeWalker.new("::1")
       expect(walker).to be_valid
       expect(walker.length).to eq 1
@@ -73,7 +73,7 @@ RSpec.describe Rex::Socket::RangeWalker do
       expect(walker.next).to eq "::%lo"
     end
 
-    context "with mulitple ranges" do
+    context "with multiple ranges" do
       let(:args) { "1.1.1.1-2 2.1-2.2.2 3.1-2.1-2.1 " }
       it { is_expected.to be_valid }
       it { expect(subject.length).to eq(8) }
@@ -101,6 +101,11 @@ RSpec.describe Rex::Socket::RangeWalker do
 
     it 'should reject a CIDR range with too many octets' do
       walker = Rex::Socket::RangeWalker.new('192.168.1.2.0/24')
+      expect(walker).not_to be_valid
+    end
+
+    it 'should reject an IPv4 address with too many octets' do
+      walker = Rex::Socket::RangeWalker.new('192.0.2.0.0')
       expect(walker).not_to be_valid
     end
 


### PR DESCRIPTION
In my [previous PR](https://github.com/rapid7/rex-socket/pull/28) as part of refactoring this, I introduced some changes in the behavior of how the `RangeWalker` fails (whoops 😅 ). This corrects those changes to maintain consistency and adds some unit tests so they don't change in the future 🎉 .

This should fix the test failures for rapid7/metasploit-framework#14918.

The main issue is that when multiple things are passed to the RangeWalker, it should gracefully skip the entries that are invalid and keep the ones that are valid. In practice, this meant I needed to switch from returning false to just advancing the loop iteration. I also updated `#expand_nmap` to consistently return `nil` like all of the other parsing functions do when they fail.

## Testing Steps

- [x] Run the new unit tests in isolation, see that they all pass
- [x] Run the unit tests and see that they fix the failures observed in the Metasploit PR<sup>1</sup>

<sup>1</sup>The Metasploit unit tests that are currently failing can be run on their own which is faster using:

```
bundle exec rake db:drop db:create db:migrate RAILS_ENV=test
bundle exec rspec ./spec/models/mdm/workspace_spec.rb
bundle exec rspec ./spec/lib/msf/core/opt_address_range_spec.rb
```