### PR TITLE
Consistently return nil as the failure indicator

### DIFF
--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -134,7 +134,7 @@ class RangeWalker
   #
   # @return [Hash<Symbol, String>] The next host in the range
   def next_host
-    return false if not valid?
+    return unless valid?
 
     if (@curr_addr > @ranges[@curr_range_index].stop)
       # Then we are at the end of this range. Grab the next one.
@@ -247,7 +247,7 @@ class RangeWalker
   def expand_cidr(arg)
     start,stop = Rex::Socket.cidr_crack(arg)
     if !start or !stop
-      return false
+      return
     end
     range = Range.new
     range.start = Rex::Socket.addr_atoi(start)
@@ -399,7 +399,7 @@ class RangeWalker
     return if !valid_cidr_chars?(arg)
 
     ip_part, mask_part = arg.split("/")
-    return false unless (0..32).include? mask_part.to_i
+    return unless (0..32).include? mask_part.to_i
     if ip_part =~ /^\d{1,3}(\.\d{1,3}){1,3}$/
       return unless Rex::Socket.is_ipv4?(ip_part)
     end

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -123,6 +123,11 @@ RSpec.describe Rex::Socket::RangeWalker do
       expect(walker.length).to eq 1
     end
 
+    it 'should reject an IPv4 range with too few octets' do
+      walker = Rex::Socket::RangeWalker.new('127.0.0.2-1')
+      expect(walker).not_to be_valid
+    end
+
     it 'should reject an IPv6 address with too many octets' do
       walker = Rex::Socket::RangeWalker.new('0:1:2:3:4:5:6:7:8')
       expect(walker).not_to be_valid
@@ -197,16 +202,30 @@ RSpec.describe Rex::Socket::RangeWalker do
   end
 
   describe '#each_ip' do
-    let(:args) { "10.1.1.1-2,2,3 10.2.2.2" }
+    context 'when created with an invalid range' do
+      let(:args) { "127.0.0.2-1" }
 
-    it "should yield all ips" do
-      got = []
-      walker.each_ip { |ip|
-        got.push ip
-      }
-      expect(got).to eq ["10.1.1.1", "10.1.1.2", "10.1.1.3", "10.2.2.2"]
+      it 'should not yield any IPs' do
+        got = []
+        walker.each_ip { |ip|
+          got.push ip
+        }
+
+        expect(got).to eq []
+      end
     end
 
+    context 'when created with a valid range' do
+      let(:args) { "10.1.1.1-2,2,3 10.2.2.2" }
+
+      it "should yield all ips" do
+        got = []
+        walker.each_ip { |ip|
+          got.push ip
+        }
+        expect(got).to eq ["10.1.1.1", "10.1.1.2", "10.1.1.3", "10.2.2.2"]
+      end
+    end
   end
 
   describe '#each_host' do


### PR DESCRIPTION
Consistently use `nil` to indicate failure instead of a mixed usage of `false` and `nil`.

This should fix a private unit test.