### PR TITLE
Fix Default IPv6 LocalHost

### DIFF
--- a/spec/rex/socket/parameters_spec.rb
+++ b/spec/rex/socket/parameters_spec.rb
@@ -15,20 +15,37 @@ RSpec.describe Rex::Socket::Parameters do
 
   describe '.new' do
 
-    it "should handle an IPv4 local host definition" do
-      params = Rex::Socket::Parameters.new({ "LocalHost" => "1.2.3.4", "LocalPort" => 1234 })
-      expect(params.localhost).to eq ("1.2.3.4")
+    it 'should handle an IPv4 local host definition' do
+      params = Rex::Socket::Parameters.new({ 'LocalHost' => '1.2.3.4', 'LocalPort' => 1234 })
+      expect(params.localhost).to eq '1.2.3.4'
       expect(params.localport).to eq 1234
       expect(params.v6?).to eq false
     end
 
-    it "should handle an IPv6 local host definition" do
-      params = Rex::Socket::Parameters.new({ "LocalHost" => "::1", "LocalPort" => 1234, "IPv6" => true })
-      expect(params.localhost).to eq ("::1")
+    it 'should handle an IPv4 peer host definition' do
+      params = Rex::Socket::Parameters.new({ 'PeerHost' => '1.2.3.4', 'PeerPort' => 1234 })
+      expect(params.localhost).to eq '0.0.0.0'
+      expect(params.localport).to eq 0
+      expect(params.peerhost).to eq '1.2.3.4'
+      expect(params.peerport).to eq 1234
+      expect(params.v6?).to eq false
+    end
+
+    it 'should handle an IPv6 local host definition' do
+      params = Rex::Socket::Parameters.new({ 'LocalHost' => '::1', 'LocalPort' => 1234, 'IPv6' => true })
+      expect(params.localhost).to eq '::1'
       expect(params.localport).to eq 1234
       expect(params.v6?).to eq true
     end
 
+    it 'should handle an IPv6 peer host definition' do
+      params = Rex::Socket::Parameters.new({ 'PeerHost' => '::1', 'PeerPort' => 1234, 'IPv6' => true })
+      expect(params.localhost).to eq '::'
+      expect(params.localport).to eq 0
+      expect(params.peerhost).to eq '::1'
+      expect(params.peerport).to eq 1234
+      expect(params.v6?).to eq true
+    end
   end
 
   describe '#merge' do

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -184,4 +184,71 @@ RSpec.describe Rex::Socket do
     end
   end
 
+  describe '.is_ipv4?' do
+    subject(:addr) do
+      described_class.is_ipv4?(try)
+    end
+
+    context 'with an IPv4 address' do
+      let(:try) { '0.0.0.0' }
+      it 'should return true' do
+        expect(addr).to eq true
+      end
+    end
+
+    context 'with an IPv6 address' do
+      let(:try) { '::1' }
+      it 'should return false' do
+        expect(addr).to eq false
+      end
+    end
+
+   context 'with a hostname' do
+      let(:try) { "localhost" }
+      it "should return false" do
+        expect(addr).to eq false
+      end
+   end
+
+    context 'with nil' do
+      let(:try) { nil }
+      it "should return false" do
+        expect(addr).to eq false
+      end
+    end
+  end
+
+  describe '.is_ipv6?' do
+    subject(:addr) do
+      described_class.is_ipv6?(try)
+    end
+
+    context 'with an IPv4 address' do
+      let(:try) { '0.0.0.0' }
+      it 'should return false' do
+        expect(addr).to eq false
+      end
+    end
+
+    context 'with an IPv6 address' do
+      let(:try) { '::' }
+      it 'should return true' do
+        expect(addr).to eq true
+      end
+    end
+
+    context 'with a hostname' do
+      let(:try) { "localhost" }
+      it "should return false" do
+        expect(addr).to eq false
+      end
+    end
+
+    context 'with nil' do
+      let(:try) { nil }
+      it "should return false" do
+        expect(addr).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
This updates the `Rex::Socket::Parameters` to intelligently identify when IPv6 should be used while still defaulting to IPv4 when no explicit IPv6 address is specified. This fixes the localhost value to be a proper IPv6 address when it is not specified by the peer as an IPv6 address. The localhost is printed in quite a few locations in Metasploit and can be confusing when it shows something to the effect of `0.0.0.0 -> ::1`.

This also adds quite a few unit tests to ensure that the automatic identification of when to use IPv6 is correct. Of course, explicitly setting the `IPv6` value will supersede the logic. As far as I can tell the local and peer hosts can be one of 4 things, `nil`, a hostname, and IPv4 address or an IPv6 address. A full set of all combinations are included in the unit test and demonstrate when v6 will be set.

This also relies on `#is_ipv4?` and `#is_ipv6?` returning `false` for `nil` as opposed to throwing an exception because the value is not a string. I added a test for this as well to ensure it doesn't change in the future.

Fixes #34

## Verification

- [x] Ensure all of the unit tests pass
- [x] Create parameters to an IPv6 peer, not specifying the local host and see that the localhost is now `::`
- [x] Create parameters to an IPv4 peer, not specifying the local host and see that the localhost is still `0.0.0.0`