### PR TITLE
Use getsockname to get the real local info

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -730,7 +730,7 @@ module Socket
   # Wrapper around getsockname that stores the local address and local port values.
   #
   def getlocalname
-    if self.localhost.nil? && self.localport.nil?
+    if [nil, '0.0.0.0', '::'].include?(self.localhost) && [nil, 0].include?(self.localport)
       _, self.localhost, self.localport = getsockname
     end
 


### PR DESCRIPTION
This updates `#getlocalname` which caches the address and port to defer to `#getsockname` not only when both values are nil but also when both values are their special any values. This means that the actual IP address the socket is bound to along with it's port number can now be access through the `localhost` and `localport` attributes which provides better information in places where it's printed in Metasploit. This information is typically printed as diagnostic information around connections to show the source.

Fixes #33

## Verification
- [x] Create a local server socket (`server = Rex::Socket::TcpServer.create({'LocalPort' => 0})`)
- [x] Call `#getlocalname` and see a real port number, the IP address will still be `0.0.0.0` by default since it's bound to all interface
- [x] Create a client TCP socket (`sock4 = Rex::Socket::Tcp.create({'PeerHost' => 'metasploit.com', 'PeerPort' => 443})`
- [x] Call `#getlocalname` and see a real, local IP address and port number

## Example
As one example of where this information is printed to the user, see msfconsole's `connect` command:

### Before
```
msf6 exploit(windows/smb/psexec) > connect metasploit.com 80
[*] Connected to metasploit.com:80 (via: 0.0.0.0:0)
```

### After
```
msf6 exploit(windows/smb/psexec) > connect metasploit.com 80
[*] Connected to metasploit.com:80 (via: 192.168.250.87:41417)
```
