### PR TITLE
Honor the SSLVersion for server sockets

### DIFF
--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -110,10 +110,7 @@ class Rex::Socket::Parameters
       self.sslctx = hash['SSLContext']
     end
 
-    supported_ssl_versions = ['Auto', 'SSL2', 'SSL23', 'TLS1', 'SSL3', :Auto, :SSLv2, :SSLv3, :SSLv23, :TLSv1]
-    if (hash['SSLVersion'] and supported_ssl_versions.include? hash['SSLVersion'])
-      self.ssl_version = hash['SSLVersion']
-    end
+    self.ssl_version = hash.fetch('SSLVersion', nil)
 
     supported_ssl_verifiers = %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}
     if (hash['SSLVerifyMode'] and supported_ssl_verifiers.include? hash['SSLVerifyMode'])
@@ -383,7 +380,27 @@ class Rex::Socket::Parameters
 
   # What version of SSL to use (Auto, SSL2, SSL3, SSL23, TLS1)
   # @return [String,Symbol]
-  attr_accessor :ssl_version
+  attr_reader :ssl_version
+  def ssl_version=(version)
+    # Let the caller specify a particular SSL/TLS version
+    case version
+    when 'SSL2'
+      version = :SSLv2
+    # 'TLS' will be the new name for autonegotation with newer versions of OpenSSL
+    when 'SSL23', 'TLS', 'Auto'
+      version = :SSLv23
+    when 'SSL3'
+      version = :SSLv3
+    when 'TLS1','TLS1.0'
+      version = :TLSv1
+    when 'TLS1.1'
+      version = :TLSv1_1
+    when 'TLS1.2'
+      version = :TLSv1_2
+    end
+
+    @ssl_version = version
+  end
 
   # What specific SSL Cipher(s) to use, may be a string containing the cipher
   # name or an array of strings containing cipher names e.g.

--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -129,7 +129,7 @@ module Rex::Socket::Ssl
     # Raise an error if no selected versions are supported
     unless Rex::Socket::SslTcp.system_ssl_methods.include? version
       raise ArgumentError,
-        "This version of Ruby does not support the requested SSL/TLS version #{ssl_version}"
+        "This version of Ruby does not support the requested SSL/TLS version #{version}"
     end
 
     ctx = OpenSSL::SSL::SSLContext.new(version)

--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -125,7 +125,14 @@ module Rex::Socket::Ssl
       key, cert, chain = ssl_generate_certificate(cert_vars: {cn: params.ssl_cn})
     end
 
-    ctx = OpenSSL::SSL::SSLContext.new()
+    version = params&.ssl_version || DEFAULT_SSL_VERSION
+    # Raise an error if no selected versions are supported
+    unless Rex::Socket::SslTcp.system_ssl_methods.include? version
+      raise ArgumentError,
+        "This version of Ruby does not support the requested SSL/TLS version #{ssl_version}"
+    end
+
+    ctx = OpenSSL::SSL::SSLContext.new(version)
     ctx.key = key
     ctx.cert = cert
     ctx.extra_chain_cert = chain

--- a/lib/rex/socket/ssl.rb
+++ b/lib/rex/socket/ssl.rb
@@ -11,6 +11,9 @@ require 'openssl'
 ###
 module Rex::Socket::Ssl
 
+  # Default to SSLv23 (automatically negotiate)
+  DEFAULT_SSL_VERSION = :SSLv23
+
   module CertProvider
 
     def self.ssl_generate_subject(cn: nil, org: nil, loc: nil, st: nil)

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -65,35 +65,14 @@ begin
   def initsock(params = nil)
     super
 
-    # Default to SSLv23 (automatically negotiate)
-    version = :SSLv23
-
-    # Let the caller specify a particular SSL/TLS version
-    if params
-      case params.ssl_version
-      when 'SSL2', :SSLv2
-        version = :SSLv2
-      # 'TLS' will be the new name for autonegotation with newer versions of OpenSSL
-      when 'SSL23', :SSLv23, 'TLS', 'Auto'
-        version = :SSLv23
-      when 'SSL3', :SSLv3
-        version = :SSLv3
-      when 'TLS1','TLS1.0', :TLSv1
-        version = :TLSv1
-      when 'TLS1.1', :TLSv1_1
-        version = :TLSv1_1
-      when 'TLS1.2', :TLSv1_2
-        version = :TLSv1_2
-      end
-    end
-
+    version = params&.ssl_version || Rex::Socket::Ssl::DEFAULT_SSL_VERSION
     # Raise an error if no selected versions are supported
     unless Rex::Socket::SslTcp.system_ssl_methods.include? version
       raise ArgumentError,
-        "This version of Ruby does not support the requested SSL/TLS version #{params.ssl_version}"
+        "This version of Ruby does not support the requested SSL/TLS version #{version}"
     end
 
-    # Try intializing the socket with this SSL/TLS version
+    # Try initializing the socket with this SSL/TLS version
     # This will throw an exception if it fails
     initsock_with_ssl_version(params, version)
 


### PR DESCRIPTION
This updates the SSL server socket implementation to honor the same SSLVersion option as its client counter part does. This notably makes it default to autonegotiate the supported version which increases compatibility with clients (such as connections from Windows 7). **This could also be seen as a security vulnerability since we're adding support for older SSL ciphers that are no longer considered secure.** I did it this way to use the same default value as what the client is using, effectively keeping them the same. If we want to default to a newer cipher, that's fine we'll just want to make sure that Metasploit's handlers are either updated to use older ciphers or be configurable by the user to support older ciphers.

This fixes rapid7/metasploit-framework#15435.

## Testing
Follow the steps from the referenced issue. At this time, Metasploit does not pass the `SSLVersion` datastore option to the parameters that are used to create a handler socket. That means the default value from this PR is used. On a newer system like the Fedora 34 instance I used for testing, this patch will cause the server to accept TLSv1.0 connections.

- [x] Load Metasploit and start reverse_tcp listener with SSL (use the `payloads/windows/powershell_reverse_tcp` module)
- [x] Run SSLScan against the listener to see the SSL versions that are supported
- [ ] Verify that with the patch, the supported versions are greater than or equal to the supported versions without the patch (on a system affected by the issue, the number of versions will be greater than)