### PR TITLE
Set underlying comm value during initialization and do not change it

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -707,6 +707,7 @@ module Socket
       self.peerport  = params.peerport
       self.localhost = params.localhost
       self.localport = params.localport
+      self.comm      = params.comm
       self.context   = params.context || {}
       self.ipv       = params.v6 ? 6 : 4
     end
@@ -795,6 +796,10 @@ module Socket
   #
   attr_reader :localport
   #
+  # The underlying communication channel used by this socket.
+  #
+  attr_reader :comm
+  #
   # The IP version of the socket
   #
   attr_reader :ipv
@@ -807,7 +812,7 @@ module Socket
 
 protected
 
-  attr_writer :peerhost, :peerport, :localhost, :localport # :nodoc:
+  attr_writer :peerhost, :peerport, :localhost, :localport, :comm # :nodoc:
   attr_writer :context # :nodoc:
   attr_writer :ipv # :nodoc:
 


### PR DESCRIPTION
This change supports [PR 15706](https://github.com/rapid7/metasploit-framework/pull/15706) in Metasploit.

The fact that `comm` could change at any time (i.e. as the route table changes) made it very difficult to reason about the state of the parameters object. If the route table is changed after a session is established, then the params object associated with the session object could then change its `comm` value. It is helpful for a Metasploit session object to use the params object to initialize sockets; but if they could change between creation of the session and creation of the socket, this introduces a race condition whereby a session is appropriately set up, but a socket it creates (e.g. via TCP forwarding) believes it's being passed through a different session, or none at all.

This commit also adds the `comm` attribute to sockets, so that sockets can deduce which session they're listening on.