### PR TITLE
Prevent DNS leaks & pivot using optional resolver

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -893,6 +893,9 @@ protected
     if !v4 and !v6
       raise ::SocketError.new('getaddrinfo: Name or service not known')
     end
+    [v4, v6].compact.map do |ans|
+      ans = resolver.send(ans.name).answer.first unless ans.respond_to?(:address)
+    end
     # Build response array
     getaddrinfo = []
     getaddrinfo << Addrinfo.new(

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -918,12 +918,20 @@ protected
       "Rex::Socket internal DNS resolution requires passing a String name to resolve"
     ) unless name.is_a?(String)
     # Pull both record types
-    v4 = resolver.send(name, ::Net::DNS::A).answer.select {
-      |a| a.type == Dnsruby::Types::A}.sort_by {|a| a.address.to_s
-    }
-    v6 = resolver.send(name, ::Net::DNS::AAAA).answer.select {|a|
-      a.type == Dnsruby::Types::AAAA}.sort_by {|a| a.address.to_s
-    }
+    v4 = begin
+      resolver.send(name, ::Net::DNS::A).answer.select {|a|
+        a.type == Dnsruby::Types::A}.sort_by {|a| a.address.to_s
+      }
+    rescue
+      [nil]
+    end
+    v6 = begin
+      resolver.send(name, ::Net::DNS::AAAA).answer.select {|a|
+        a.type == Dnsruby::Types::AAAA}.sort_by {|a| a.address.to_s
+      }
+    rescue
+      [nil]
+    end
     # Emulate ::Socket's error if no responses found
     if !v4[0] and !v6[0]
       raise ::SocketError.new('getaddrinfo: Name or service not known')

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -855,48 +855,54 @@ protected
   attr_writer :context # :nodoc:
   attr_writer :ipv # :nodoc:
 
-  def self.rex_gethostbyname(name)
+  def self.rex_gethostbyname(name, resolver = @@resolver)
+    raise ::SocketError.new(
+      "Rex::Socket internal DNS resolution requires passing/setting a resolver"
+    ) unless resolver
     # Pull both record types
-    v4 = @@resolver.send(name, ::Net::DNS::A).answer.first
-    v6 = @@resolver.send(name, ::Net::DNS::AAAA).answer.first
+    v4 = resolver.send(name, ::Net::DNS::A).answer.first
+    v6 = resolver.send(name, ::Net::DNS::AAAA).answer.first
     # Emulate ::Socket's error if no responses found
     if !v4 and !v6
-      raise SocketError.new('getaddrinfo: Name or service not known')
+      raise ::SocketError.new('getaddrinfo: Name or service not known')
     end
     # Build response array
     hostbyname = [name, []]
     if v4
-      hostbyname << Socket::AF_INET
+      hostbyname << ::Socket::AF_INET
       hostbyname << self.addr_aton(v4.address.to_s)
       hostbyname << self.addr_aton(v6.address.to_s) if v6
     else
-      hostbyname << Socket::AF_INET6
+      hostbyname << ::Socket::AF_INET6
       hostbyname << self.addr_aton(v6.address.to_s)
     end
     return hostbyname
   end
 
-  def self.rex_getaddrinfo(name)
+  def self.rex_getaddrinfo(name, resolver = @@resolver)
+    raise ::SocketError.new(
+      "Rex::Socket internal DNS resolution requires passing/setting a resolver"
+    ) unless resolver
     # Pull both record types
-    v4 = @@resolver.send(name, ::Net::DNS::A).answer.first
-    v6 = @@resolver.send(name, ::Net::DNS::AAAA).answer.first
+    v4 = resolver.send(name, ::Net::DNS::A).answer.first
+    v6 = resolver.send(name, ::Net::DNS::AAAA).answer.first
     # Emulate ::Socket's error if no responses found
     if !v4 and !v6
-      raise SocketError.new('getaddrinfo: Name or service not known')
+      raise ::SocketError.new('getaddrinfo: Name or service not known')
     end
     # Build response array
     getaddrinfo = []
     getaddrinfo << Addrinfo.new(
       self.to_sockaddr(v4.address.to_s,0),
-      Socket::AF_INET,
-      Socket::SOCK_STREAM,
-      Socket::IPPROTO_TCP,
+      ::Socket::AF_INET,
+      ::Socket::SOCK_STREAM,
+      ::Socket::IPPROTO_TCP,
     ) if v4
     getaddrinfo << Addrinfo.new(
       self.to_sockaddr(v6.address.to_s,0),
-      Socket::AF_INET6,
-      Socket::SOCK_STREAM,
-      Socket::IPPROTO_TCP,
+      ::Socket::AF_INET6,
+      ::Socket::SOCK_STREAM,
+      ::Socket::IPPROTO_TCP,
     ) if v6
     return getaddrinfo
   end

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -216,7 +216,11 @@ module Socket
       return [hostname]
     end
 
-    res = ::Addrinfo.getaddrinfo(hostname, 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM)
+    res = if @@resolver
+      self.rex_getaddrinfo(hostname)
+    else
+      ::Addrinfo.getaddrinfo(hostname, 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM)
+    end
 
     res.map! do |address_info|
       address_info.ip_address
@@ -248,7 +252,7 @@ module Socket
       host, _ = host.split('%', 2)
     end
 
-    ::Socket.gethostbyname(host)
+    @@resolver ? self.rex_gethostbyname(host) : ::Socket.gethostbyname(host)
   end
 
   #
@@ -719,6 +723,13 @@ module Socket
     return [lsock, rsock]
   end
 
+  #
+  # Install Rex::Proto::DNS::Resolver, or similar, to pivot DNS
+  #
+  def self._install_global_resolver(res)
+    @@resolver = res
+  end
+
 
   ##
   #
@@ -844,6 +855,51 @@ protected
   attr_writer :context # :nodoc:
   attr_writer :ipv # :nodoc:
 
+  def self.rex_gethostbyname(name)
+    # Pull both record types
+    v4 = @@resolver.send(name, ::Net::DNS::A).answer.first
+    v6 = @@resolver.send(name, ::Net::DNS::AAAA).answer.first
+    # Emulate ::Socket's error if no responses found
+    if !v4 and !v6
+      raise SocketError.new('getaddrinfo: Name or service not known')
+    end
+    # Build response array
+    hostbyname = [name, []]
+    if v4
+      hostbyname << Socket::AF_INET
+      hostbyname << self.addr_aton(v4.address.to_s)
+      hostbyname << self.addr_aton(v6.address.to_s) if v6
+    else
+      hostbyname << Socket::AF_INET6
+      hostbyname << self.addr_aton(v6.address.to_s)
+    end
+    return hostbyname
+  end
+
+  def self.rex_getaddrinfo(name)
+    # Pull both record types
+    v4 = @@resolver.send(name, ::Net::DNS::A).answer.first
+    v6 = @@resolver.send(name, ::Net::DNS::AAAA).answer.first
+    # Emulate ::Socket's error if no responses found
+    if !v4 and !v6
+      raise SocketError.new('getaddrinfo: Name or service not known')
+    end
+    # Build response array
+    getaddrinfo = []
+    getaddrinfo << Addrinfo.new(
+      self.to_sockaddr(v4.address.to_s,0),
+      Socket::AF_INET,
+      Socket::SOCK_STREAM,
+      Socket::IPPROTO_TCP,
+    ) if v4
+    getaddrinfo << Addrinfo.new(
+      self.to_sockaddr(v6.address.to_s,0),
+      Socket::AF_INET6,
+      Socket::SOCK_STREAM,
+      Socket::IPPROTO_TCP,
+    ) if v6
+    return getaddrinfo
+  end
 end
 
 end

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -219,10 +219,10 @@ module Socket
       return [hostname]
     end
 
-    res = if @@resolver
-      self.rex_getaddrinfo(hostname)
+    if @@resolver
+      res = self.rex_getaddrinfo(hostname)
     else
-      ::Addrinfo.getaddrinfo(hostname, 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM)
+      res = ::Addrinfo.getaddrinfo(hostname, 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM)
     end
 
     res.map! do |address_info|

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -122,6 +122,9 @@ module Socket
   end
 
   #
+  # Cache our resolver
+  @@resolver = nil
+
   # Determine whether this is an IPv4 address
   #
   def self.is_ipv4?(addr)
@@ -724,7 +727,7 @@ module Socket
   end
 
   #
-  # Install Rex::Proto::DNS::Resolver, or similar, to pivot DNS
+  # Install Rex::Proto::DNS::CachedResolver, or similar, to pivot DNS
   #
   def self._install_global_resolver(res)
     @@resolver = res


### PR DESCRIPTION
`Rex::Socket` eventually ends up relying on the standard library
for name resolution in socket-related calls. Specifically, the use
of `Socket.gethostbyname` and `Addrinfo.getaddrinfo` can lead to
the use of system DNS, recursing into places where users may not
want to send DNS requests.

Implement a mechanism to set a global name resolver for all of
`Rex::Socket` producing `.get('msf.io')` output analogous to that
of `Rex::Proto::DNS::Resolver`. Once that resolver is in-place,
the class method calls will be diverted to internal ones using
said resolver to create API-compatible output structures
feeding transparently back to the caller. Unlike approaches using
`Rex::Socket::SwitchBoard` directly, this mechanism can't create
loops in the stack as the `Resolver` uses IP-based NS' and cannot
get stuck looking up the name servers against which to look-up...

Clean up raw calls to `Socket` and ensure that all `gethostbyname`
calls are properly wrapped.

Note: a fully-compatible resolver would cache DNS requests until
the TTL on them expires and honor the local system hostsfile just
like the native standard library does. However, that would fall
into `rex/proto` or other parts of the ecosystem and not in-scope
for this repository. As a result, the operating semantic of this
library is unchanged by default and requires input of a relevant
`Resolver` from other components which are capable of constructing
and configuring one as appropriate.

Resolver tasks:
Optimize for performance and concurrent access (w/ Rex::Proto)
Review options for per-caller instantiation or NS passing by the
caller to permit dynamic dispatch to pivoted nameservers past the
`SwitchBoard` - this is likely to be handled by the mechanism which
will deal with the hostsfile concern such as to use session and
workspace data to determine which NS to query for an FQDN and how.
