### PR TITLE
Ignore trailing commas in range walker

### DIFF
--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -81,6 +81,8 @@ class RangeWalker
 
     ranges = []
     parseme.split(', ').map{ |a| a.split(' ') }.flatten.each do |arg|
+      # Remove trailing commas that may be unneeded, i.e. '1.1.1.1,'
+      arg = arg.sub(/,+$/, '')
 
       # Handle IPv6 CIDR first
       if arg.include?(':') && arg.include?('/')

--- a/spec/rex/socket/range_walker_spec.rb
+++ b/spec/rex/socket/range_walker_spec.rb
@@ -165,6 +165,18 @@ RSpec.describe Rex::Socket::RangeWalker do
       expect(walker).to include("10.1.255.3")
     end
 
+    it "should ignore trailing commas" do
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1")
+      expect(walker).to be_valid
+      expect(walker.length).to eq 1
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1,")
+      expect(walker).to be_valid
+      expect(walker.length).to eq 1
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1,,,,,")
+      expect(walker).to be_valid
+      expect(walker.length).to eq 1
+    end
+
     it "should handle lists" do
       walker = Rex::Socket::RangeWalker.new("10.1.1.1")
       expect(walker).to be_valid


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/16428

### Before

Trailing commas resolve to 2 hosts

```
msf6 auxiliary(scanner/http/title) > run 1.1.1.1, 2.2.2.2

[*] Scanned 1 of 3 hosts (33% complete)
[+] [1.1.1.1:80] [C:301] [R:https://1.1.1.1/] [S:cloudflare] 301 Moved Permanently
[*] Scanned 2 of 3 hosts (66% complete)
[*] Scanned 2 of 3 hosts (66% complete)
[*] Scanned 2 of 3 hosts (66% complete)
[*] Scanned 2 of 3 hosts (66% complete)
[*] Scanned 2 of 3 hosts (66% complete)
[*] Scanned 3 of 3 hosts (100% complete)
[*] Auxiliary module execution completed
```

```
msf6 auxiliary(scanner/http/title) > run 1.1.1.1,

[*] Scanned 1 of 2 hosts (50% complete)
[+] [1.1.1.1:80] [C:301] [R:https://1.1.1.1/] [S:cloudflare] 301 Moved Permanently
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After

Trailing commas are ignored

```
msf6 auxiliary(scanner/http/title) > run 1.1.1.1, 2.2.2.2
[+] [1.1.1.1:80] [C:301] [R:https://1.1.1.1/] [S:cloudflare] 301 Moved Permanently
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/title) >
```

```
msf6 auxiliary(scanner/http/title) > run 1.1.1.1,

[+] [1.1.1.1:80] [C:301] [R:https://1.1.1.1/] [S:cloudflare] 301 Moved Permanently
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```