### PR TITLE
Allow explicitly setting peer hostname

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -706,6 +706,7 @@ module Socket
   def initsock(params = nil)
     if (params)
       self.peerhost  = params.peerhost
+      self.peerhostname = params.peerhostname
       self.peerport  = params.peerport
       self.localhost = params.localhost
       self.localport = params.localport
@@ -785,6 +786,10 @@ module Socket
   #
   attr_reader :peerhost
   #
+  # The peer hostname of the connected socket.
+  #
+  attr_reader :peerhostname
+  #
   # The peer port of the connected socket.
   #
   attr_reader :peerport
@@ -809,7 +814,7 @@ module Socket
 
 protected
 
-  attr_writer :peerhost, :peerport, :localhost, :localport # :nodoc:
+  attr_writer :peerhost, :peerhostname, :peerport, :localhost, :localport # :nodoc:
   attr_writer :context # :nodoc:
   attr_writer :ipv # :nodoc:
 

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -49,6 +49,7 @@ class Rex::Socket::Parameters
   # keys can be specified.
   #
   # @option hash [String] 'PeerHost' The remote host to connect to
+  # @option hash [String] 'PeerHostname' The unresolved remote hostname, used to specify Server Name Indication (SNI)
   # @option hash [String] 'PeerAddr' (alias for 'PeerHost')
   # @option hash [Fixnum] 'PeerPort' The remote port to connect to
   # @option hash [String] 'LocalHost' The local host to communicate from, if any
@@ -82,6 +83,10 @@ class Rex::Socket::Parameters
       self.peerhost = hash['PeerHost']
     elsif (hash['PeerAddr'])
       self.peerhost = hash['PeerAddr']
+    end
+
+    if (hash['PeerHostname'])
+      self.peerhostname = hash['PeerHostname']
     end
 
     if (hash['LocalHost'])
@@ -290,6 +295,11 @@ class Rex::Socket::Parameters
   # key.
   # @return [String]
   attr_accessor :peerhost
+
+  # The remote hostname information, equivalent to the PeerHostname parameter hash
+  # key.
+  # @return [String]
+  attr_accessor :peerhostname
 
   # The remote port.  Equivalent to the PeerPort parameter hash key.
   # @return [Fixnum]

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -123,10 +123,14 @@ begin
     # Tie the context to a socket
     self.sslsock = OpenSSL::SSL::SSLSocket.new(self, self.sslctx)
 
-    # If peerhost looks like a hostname, set the undocumented 'hostname'
+    # If peerhostname is set, or if hostname looks like a hostname, set the undocumented 'hostname'
     # attribute on sslsock, which enables the Server Name Indication (SNI)
     # extension
-    self.sslsock.hostname = self.peerhost if !Rex::Socket.dotted_ip?(self.peerhost)
+    if self.peerhostname
+      self.sslsock.hostname = self.peerhostname
+    else !Rex::Socket.dotted_ip?(self.peerhost)
+      self.sslsock.hostname = self.peerhost
+    end
 
     # Force a negotiation timeout
     begin


### PR DESCRIPTION
Closes https://github.com/rapid7/rex-socket/issues/29
Related to https://github.com/rapid7/metasploit-framework/pull/16378
Framework pull request: https://github.com/rapid7/rex-socket/pull/45
rex-socket pull request: https://github.com/rapid7/rex-socket/pull/45

Allow for SNI information to be set explicitly by the caller
