### PR TITLE
This fixes a bug caused by a missing require statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /tmp/
 /.ruby-version
 /.ruby-gemset
+# Rubymine project directory
+.idea

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'singleton'
+require 'rex/compat'
 require 'rex/socket'
 require 'rex/socket/tcp'
 require 'rex/socket/ssl_tcp'


### PR DESCRIPTION
`lib/rex/socket/comm/local.rb` has a couple of references to `Rex::Compat` which is provided by the [rex-core](https://github.com/rapid7/rex-core/blob/master/lib/rex/compat.rb) gem which is [already a requirement](https://github.com/rapid7/rex-socket/blob/f6f757303ca3ddbedd82f59f1edcd613f428b531/rex-socket.gemspec#L30) in rex-socket. The `require` statement however was missing, causing uncaught exceptions to be raised under certain conditions. This PR fixes that and adds a `.gitignore` entry for RubyMine's project folder.

# Testing

Run this command and *do not* see a stack trace:
`ruby -Ilib -e "require 'rex/socket'; Rex::Socket::Tcp.create('PeerHost' => 'metasploit.com', 'PeerPort' => 80)"`

Without these changes, the following stack trace or similar would be raised:

```
ruby -Ilib -e "require 'rex/socket'; Rex::Socket::Tcp.create('PeerHost' => 'metasploit.com', 'PeerPort' => 80)"
Traceback (most recent call last):
	5: from -e:1:in `<main>'
	4: from /home/smcintyre/Repositories/rex-socket/lib/rex/socket/tcp.rb:28:in `create'
	3: from /home/smcintyre/Repositories/rex-socket/lib/rex/socket/tcp.rb:37:in `create_param'
	2: from /home/smcintyre/Repositories/rex-socket/lib/rex/socket.rb:51:in `create_param'
	1: from /home/smcintyre/Repositories/rex-socket/lib/rex/socket/comm/local.rb:33:in `create'
/home/smcintyre/Repositories/rex-socket/lib/rex/socket/comm/local.rb:179:in `create_by_type': uninitialized constant Rex::Compat (NameError)
Did you mean?  Comparable
```