### PR TITLE
Fix typo in ssl_tcp.rb that would allow for dotted IPs being used for self.sslsock.hostname, which should never happen.

### DIFF
--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -128,7 +128,7 @@ begin
     # extension
     if self.peerhostname
       self.sslsock.hostname = self.peerhostname
-    else !Rex::Socket.dotted_ip?(self.peerhost)
+    elsif !Rex::Socket.dotted_ip?(self.peerhost)
       self.sslsock.hostname = self.peerhost
     end
 


### PR DESCRIPTION
Fix typo in ssl_tcp.rb that would allow for dotted IPs being used for self.sslsock.hostname, which should never happen.

Fixes #47. 

https://github.com/rapid7/rex-socket/blob/master/lib/rex/socket/ssl_tcp.rb#L131 has a bug in that it should be `elsif` not  `else `. Otherwise what happens is that the case that is provided will be ignored and we will always trigger the else condition if the above self.peerhostname condition isn't true. In reality we only want to execute that code  `if !Rex::Socket.dotted_ip?(self.peerhost)` evaluates to true, in which case we then execute `self.sslsock.hostname = self.peerhost`.

In its current case we will be setting `self.sslsock.hostname = self.peerhost` even in cases where `self.peerhost` is a dotted IP address, which defeats the purpose of the check that was added here.

We can confirm this is the case with a simple test bit of code.

```
3.0.2 :016 > if nil
3.0.2 :017 >   print "A"
3.0.2 :018 > else nil
3.0.2 :019 >   print "B"
3.0.2 :020 > end
B => nil 
3.0.2 :021 > if nil
3.0.2 :022 >   print "A"
3.0.2 :023 > elsif nil
3.0.2 :024 >   print "B"
3.0.2 :025 > end
 => nil
```

As you can see in the elsif case, both conditions are properly skipped over. However in the if...else case, the second condition is executed even though the condition passed to else was false, since else doesn't expect an argument and therefore will ignore the argument.