### PR TITLE
Do not assign blank hostname to (SSL) Socket

### DIFF
--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -127,7 +127,7 @@ begin
     # If peerhostname is set, or if hostname looks like a hostname, set the undocumented 'hostname'
     # attribute on sslsock, which enables the Server Name Indication (SNI)
     # extension
-    if self.peerhostname
+    if self.peerhostname and not self.peerhostname.strip.empty?
       self.sslsock.hostname = self.peerhostname
     elsif !Rex::Socket.dotted_ip?(self.peerhost)
       self.sslsock.hostname = self.peerhost


### PR DESCRIPTION
When `send_request_raw` includes `'vhost'  =>  ''`, Rex tries to assign the `hostname` value of a SslTcpSocket from that parameter. This throws:
```
OpenSSL::SSL::SSLError: ssl3 ext invalid servername
```

Correct this problem by checking for an empty string being assigned in the conditional preceding assignment. For correctness, we may want to down-port the `MATCH_FQDN` and `MATCH_HOSTNAME` regex' from rex/proto/dns and include proper validations for the value being assigned.

Testing:
  Local environment-only