### PR TITLE
Fix deprecation warning in socks proxy support

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -211,7 +211,7 @@ module Socket
   #
   # @deprecated Please use {#getaddress}, {#resolv_nbo}, or similar instead.
   def self.gethostbyname(host)
-    warn "NOTE: #{self}.#{__method__} is deprecated, use getaddress, resolve_nbo, or similar instead. It will be removed in the next Major version"
+    warn "NOTE: #{self}.#{__method__} is deprecated, use getaddress, resolv_nbo, or similar instead. It will be removed in the next Major version"
     if is_ipv4?(host)
       return [ host, [], 2, host.split('.').map{ |c| c.to_i }.pack("C4") ]
     end


### PR DESCRIPTION
Original issue https://github.com/rapid7/metasploit-framework/issues/15849

Fix deprecation warning in socks proxy support

Steps:

```
use server/socks_proxy
run

use scanner/http/title
run proxies=socks5:127.0.0.1:1080 https://google.com
```

### Before

Warning generated:

```
msf6 auxiliary(scanner/http/title) > run proxies=socks5:127.0.0.1:1080 https://google.com
NOTE: Rex::Socket.gethostbyname is deprecated, use getaddress, resolve_nbo, or similar instead. It will be removed in the next Major version

[+] [142.250.200.46:443] [C:301] [R:https://www.google.com/] [S:gws] 301 Moved
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After

No warning

```
msf6 auxiliary(scanner/http/title) > run proxies=socks5:127.0.0.1:1080 https://google.com

[+] [142.250.200.46:443] [C:301] [R:https://www.google.com/] [S:gws] 301 Moved
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```