### PR TITLE
Detect IPv6 address for Host on init

### DIFF
--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -542,7 +542,7 @@ class Host < Range
 
   def initialize(address, hostname=nil, options={})
     if address.is_a? String
-      options.merge!({ ipv6: address.include?(":") }) if options[:ipv6].nil?
+      options.merge!({ ipv6: Rex::Socket.is_ipv6?(address) }) if options[:ipv6].nil?
       address = Rex::Socket.addr_atoi(address)
     end
 

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -540,8 +540,11 @@ end
 class Host < Range
   attr_accessor :hostname
 
-  def initialize(address, hostname=nil, options=nil)
-    address = Rex::Socket.addr_atoi(address) if address.is_a? String
+  def initialize(address, hostname=nil, options={})
+    if address.is_a? String
+      options.merge!({ ipv6: address.include?(":") }) if options[:ipv6].nil?
+      address = Rex::Socket.addr_atoi(address)
+    end
 
     super(address, address, options)
     @hostname = hostname


### PR DESCRIPTION
Fix https://github.com/rapid7/metasploit-framework/issues/17461 by making Rex::Socket::Host aware of the address type passed to it during initialization.

Testing:
```ruby
> Rex::Socket::RangeWalker.new('localhost').to_enum.to_a
=> ["127.0.0.1", "::1"]
> Rex::Socket::RangeWalker.new('localhost').include?(("0000:"*7)+"0001")
=> true
```

Notes:
  This doesn't actually fix the logical absurdity of having mixed layer 3 address types within a Range & RangeWalker. This is yet another bandaid over an architectural concern.