### PR TITLE
Stream Control Transmission Protocol (SCTP)

### DIFF
--- a/lib/rex/socket/sctp.rb
+++ b/lib/rex/socket/sctp.rb
@@ -1,0 +1,66 @@
+# -*- coding: binary -*-
+require 'rex/socket'
+require 'rex/io/stream'
+
+class ::Socket
+  IPPROTO_SCTP = 132
+  SOL_SCTP     = 132
+end
+
+###
+#
+# This class provides methods for interacting with a SCTP client connection.
+#
+###
+module Rex::Socket::Sctp
+
+  include Rex::Socket
+  include Rex::IO::Stream
+
+  ##
+  #
+  # Factory
+  #
+  ##
+
+  #
+  # Creates the client using the supplied hash.
+  #
+  # @see create_param
+  # @see Rex::Socket::Parameters.from_hash
+  def self.create(hash = {})
+    hash['Proto'] = 'sctp'
+    self.create_param(Rex::Socket::Parameters.from_hash(hash))
+  end
+
+  #
+  # Wrapper around the base socket class' creation method that automatically
+  # sets the parameter's protocol to SCTP.
+  #
+  def self.create_param(param)
+    param.proto = 'sctp'
+    Rex::Socket.create_param(param)
+  end
+
+  ##
+  #
+  # Stream mixin implementations
+  #
+  ##
+
+  #
+  # Calls shutdown on the SCTP connection.
+  #
+  def shutdown(how = ::Socket::SHUT_RDWR)
+    begin
+      return (super(how) == 0)
+    rescue ::Exception
+    end
+  end
+
+  # returns socket type
+  def type?
+    return 'sctp'
+  end
+
+end

--- a/lib/rex/socket/sctp_server.rb
+++ b/lib/rex/socket/sctp_server.rb
@@ -1,0 +1,75 @@
+# -*- coding: binary -*-
+require 'rex/socket'
+require 'rex/socket/sctp'
+require 'rex/io/stream_server'
+
+###
+#
+# This class provides methods for interacting with a SCTP server.  It
+# implements the Rex::IO::StreamServer interface.
+#
+###
+module  Rex::Socket::SctpServer
+
+  include Rex::Socket
+  include Rex::IO::StreamServer
+
+  ##
+  #
+  # Factory
+  #
+  ##
+
+  #
+  # Creates the server using the supplied hash.
+  #
+  def self.create(hash = {})
+    hash['Proto'] = 'sctp'
+    hash['Server'] = true
+    self.create_param(Rex::Socket::Parameters.from_hash(hash))
+  end
+
+  #
+  # Wrapper around the base class' creation method that automatically sets
+  # the parameter's protocol to SCTP and sets the server flag to true.
+  #
+  def self.create_param(param)
+    param.proto  = 'sctp'
+    param.server = true
+    Rex::Socket.create_param(param)
+  end
+
+  #
+  # Accepts a child connection.
+  #
+  def accept(opts = {})
+    t = super()
+
+    # jRuby compatibility
+    if t.respond_to?('[]')
+      t = t[0]
+    end
+
+    if (t)
+      t.extend(Rex::Socket::Sctp)
+      t.context = self.context
+
+      pn = t.getpeername_as_array
+
+      # We hit a "getpeername(2)" from Ruby
+      return nil unless pn
+
+      t.peerhost = pn[1]
+      t.peerport = pn[2]
+
+      ln = t.getlocalname
+
+      t.localhost = ln[1]
+      t.localport = ln[2]
+    end
+
+    t
+  end
+
+end
+


### PR DESCRIPTION
RFC: https://www.rfc-editor.org/rfc/rfc4960.html
    
Define constants for SCTP in ::Socket namespace for IPPPROTO
and SOL.
Create param definitions and socket marshalling using the newly
defined constants.
Implement stream-server mechanics for SctpServer from TcpServer
extending the clients with Rex::Socket::Sctp upon connection.

Testing:
```ruby
svr = Rex::Socket::SctpServer.create(
  'LocalHost' => '127.0.0.1', 'LocalPort' => 8888
)
csock = nil
Thread.new { csock = svr.accept }
cli = Rex::Socket::Sctp.create(
  'PeerHost' => '127.0.0.1', 'PeerPort' => 8888
)
cli.write("test\n")
csock.gets
$stdout.write(File.read('/proc/net/sctp/eps'))
```
    
Notes:
  No idea how/whether this is going to work on non-Linux hosts
  Meterpreters will need SCTPs implementation to pivot, along with the relevant encapsulation and relay mechanics within TLVs.