### PR TITLE
Fix uninitialized const error for StreamClosedError

### DIFF
--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -251,7 +251,7 @@ begin
       return !( s == nil || s[0] == nil )
     rescue ::Errno::EBADF, ::Errno::ENOTSOCK
       raise ::EOFError
-    rescue StreamClosedError, ::IOError, ::EOFError, ::Errno::EPIPE
+    rescue ::Rex::StreamClosedError, ::IOError, ::EOFError, ::Errno::EPIPE
       #  Return false if the socket is dead
       return false
     end


### PR DESCRIPTION
This just changes the rescue in `has_read_data()` to use the explicit namespace for `Rex::StreamClosedError` using @adfoster-r7's [suggestion](https://github.com/rapid7/rex-socket/pull/58#discussion_r1165557873) for a fix.

<details><summary>Before fix</summary>

```
    241: def has_read_data?(timeout = nil)
    242:   return true if self.sslsock.pending > 0
    243: 
    244:   # Allow a timeout of "0" that waits almost indefinitely for input, this
    245:   # mimics the behavior of Rex::ThreadSafe.select() and fixes some corner
    246:   # cases of unintentional no-wait timeouts.
    247:   timeout = 3600 if (timeout and timeout == 0)
    248: 
    249:   begin
    250:     s = Rex::ThreadSafe.select( [ self.sslsock ], nil, nil, timeout )
    251:     return !( s == nil || s[0] == nil )
 => 252:   rescue ::Errno::EBADF, ::Errno::ENOTSOCK
    253:     raise ::EOFError
    254:   rescue StreamClosedError, ::IOError, ::EOFError, ::Errno::EPIPE
    255:     #  Return false if the socket is dead
    256:     return false
    257:   end
    258: end

[1] pry(#<Socket>)> raise EOFError
EOFError: EOFError
from (pry):1:in `rescue in has_read_data?'
Caused by Rex::StreamClosedError: Stream #<OpenSSL::SSL::SSLSocket:0x00007f7e248d7b98> is closed.
from /Users/space/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-core-0.1.30/lib/rex/sync/thread_safe.rb:29:in `block in select'
[2] pry(#<Socket>)> exit
[-] 127.0.0.1:7002 - Exploit failed: NameError uninitialized constant Rex::Socket::SslTcp::StreamClosedError
Did you mean?  Rex::StreamClosedError
[*] Exploit completed, but no session was created.
```

</details>

<details><summary>After fix</summary>

```
    241: def has_read_data?(timeout = nil)
    242:   return true if self.sslsock.pending > 0
    243: 
    244:   # Allow a timeout of "0" that waits almost indefinitely for input, this
    245:   # mimics the behavior of Rex::ThreadSafe.select() and fixes some corner
    246:   # cases of unintentional no-wait timeouts.
    247:   timeout = 3600 if (timeout and timeout == 0)
    248: 
    249:   begin
    250:     s = Rex::ThreadSafe.select( [ self.sslsock ], nil, nil, timeout )
    251:     return !( s == nil || s[0] == nil )
 => 252:   rescue ::Errno::EBADF, ::Errno::ENOTSOCK
    253:     raise ::EOFError
    254:   rescue ::Rex::StreamClosedError, ::IOError, ::EOFError, ::Errno::EPIPE
    255:     #  Return false if the socket is dead
    256:     return false
    257:   end
    258: end

[1] pry(#<Socket>)> raise EOFError
EOFError: EOFError
from (pry):1:in `rescue in has_read_data?'
Caused by Rex::StreamClosedError: Stream #<OpenSSL::SSL::SSLSocket:0x00007f9647867880> is closed.
from /Users/space/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-core-0.1.30/lib/rex/sync/thread_safe.rb:29:in `block in select'
[2] pry(#<Socket>)> exit

^C
Abort session 1? [y/N]  y

[*] 127.0.0.1 - Command shell session 1 closed.  Reason: User exit
```

</details>
