### PR TITLE
Fix crash when running socks proxy4a comm

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -212,7 +212,7 @@ class Rex::Socket::Comm::Local
             klass = Rex::Socket::SctpServer
         else
           raise Rex::BindFailed.new(param.localhost, param.localport), caller
-        end  
+        end
         sock.extend(klass)
 
         sock.initsock(param)
@@ -447,7 +447,7 @@ class Rex::Socket::Comm::Local
       end
     when 'socks4'
       supports_ipv6 = false
-      setup = [4,1,port.to_i].pack('CCn') + Socket.resolv_nbo(host, supports_ipv6) + Rex::Text.rand_text_alpha(rand(8)+1) + "\x00"
+      setup = [4,1,port.to_i].pack('CCn') + Rex::Socket.resolv_nbo(host, supports_ipv6) + Rex::Text.rand_text_alpha(rand(8)+1) + "\x00"
       size = sock.put(setup)
       if size != setup.length
         raise Rex::ConnectionProxyError.new(host, port, type, "Failed to send the entire request to the proxy"), caller
@@ -478,7 +478,7 @@ class Rex::Socket::Comm::Local
 
       if Rex::Socket.is_ipv4?(host)
         accepts_ipv6 = false
-        addr = Rex::Socket.resolv_nbo(host)
+        addr = Rex::Socket.resolv_nbo(host, accepts_ipv6)
         setup = [5,1,0,1].pack('C4') + addr + [port.to_i].pack('n')
       elsif Rex::Socket.support_ipv6? && Rex::Socket.is_ipv6?(host)
         # IPv6 stuff all untested


### PR DESCRIPTION
Continuation of https://github.com/rapid7/rex-socket/pull/54


Fixes the following crash when running a module through a socks 4 module:

```
msf6 > use server/socks_proxy
msf6 auxiliary(server/socks_proxy) > run version=4a
[*] Auxiliary module running as background job 0.
msf6 auxiliary(server/socks_proxy) > 

[*] Starting the SOCKS proxy server
msf6 auxiliary(server/socks_proxy) > use scanner/http/title
msf6 auxiliary(scanner/http/title) > run proxies=socks4:127.0.0.1:1080 https://google.com

[-] Auxiliary failed: NoMethodError undefined method `resolv_nbo' for Socket:Class
[-] Call stack:
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/comm/local.rb:450:in `proxy'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/comm/local.rb:333:in `block in create_by_type'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/comm/local.rb:329:in `each'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/comm/local.rb:329:in `each_with_index'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/comm/local.rb:329:in `create_by_type'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/comm/local.rb:36:in `create'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket.rb:51:in `create_param'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/tcp.rb:37:in `create_param'
[-]   /Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/rex-socket-0.1.49/lib/rex/socket/tcp.rb:28:in `create'
[-]   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/http/client.rb:180:in `connect'
[-]   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/http/client.rb:264:in `send_request'
[-]   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/http/client.rb:242:in `_send_recv'
[-]   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/http/client.rb:216:in `send_recv'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/http_client.rb:375:in `send_request_raw'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/http_client.rb:417:in `send_request_cgi'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/http/title.rb:59:in `run_host'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed

```

The following steps were tested:

Socks 4
```
use server/socks_proxy
run version=4a

use scanner/http/title
run proxies=socks4:127.0.0.1:1080 https://google.com
```

Socks 5

```
use server/socks_proxy
run

use scanner/http/title
run proxies=socks5:127.0.0.1:1080 https://google.com
```

### Verification

Socks 4

```
msf6 > use server/socks_proxy
msf6 auxiliary(server/socks_proxy) > run
[*] Auxiliary module running as background job 0.
msf6 auxiliary(server/socks_proxy) > 

[*] Starting the SOCKS proxy server
msf6 auxiliary(server/socks_proxy) > use scanner/http/title
run proxies=socks4:127.0.0.1:1080 https://google.com

msf6 auxiliary(scanner/http/title) > run proxies=socks4:127.0.0.1:1080 https://google.com

[+] [142.250.178.14:443] [C:301] [R:https://www.google.com/] [S:gws] 301 Moved
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

socks5:

```
msf6 auxiliary(scanner/http/title) > use server/socks_proxy
msf6 auxiliary(server/socks_proxy) > run
[*] Auxiliary module running as background job 1.

[*] Starting the SOCKS proxy server
msf6 auxiliary(server/socks_proxy) > 
msf6 auxiliary(server/socks_proxy) > use scanner/http/title
msf6 auxiliary(scanner/http/title) > run proxies=socks5:127.0.0.1:1080 https://google.com

[+] [142.250.178.14:443] [C:301] [R:https://www.google.com/] [S:gws] 301 Moved
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```