### PR TITLE
Fix hanging forever if rsock doesnt connect

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 40
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby:
           - '2.7'
@@ -39,20 +39,20 @@ jobs:
           - '3.2'
         os:
           - ubuntu-20.04
+          - windows-2019
+          - macos-11
           - ubuntu-latest
         exclude:
           - { os: ubuntu-latest, ruby: '2.7' }
           - { os: ubuntu-latest, ruby: '3.0' }
-        test_cmd:
-          - bundle exec rspec
 
     env:
       RAILS_ENV: test
 
-    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -60,9 +60,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - name: ${{ matrix.test_cmd }}
+      - name: rspec
         run: |
-          echo "${CMD}"
-          bash -c "${CMD}"
-        env:
-          CMD: ${{ matrix.test_cmd }}
+          bundle exec rspec


### PR DESCRIPTION
Fix hanging forever if rsock doesn't connect in 

Forced test scenario:

```
diff --git a/lib/msf/ui/web/web_console.rb b/lib/msf/ui/web/web_console.rb
index 042f162465..99cfa8a04c 100644
--- a/lib/msf/ui/web/web_console.rb
+++ b/lib/msf/ui/web/web_console.rb
@@ -51,6 +51,14 @@ class WebConsole
     self.console_id = console_id
 
     # Create a new pipe
+
+    100_000.times do |x|
+      $stderr.puts "creating a pipe #{x}!"
+      my_pipe = WebConsolePipe.new
+      $stderr.puts "pipe created"
+      my_pipe = nil
+    end
+
     self.pipe = WebConsolePipe.new
 
```

Running tests:

```
bundle exec rspec ./spec/lib/msf/core/rpc/v10/rpc_console_spec.rb              
```

Against Metasploit version `6b20c19964`

Expected test failure on OSX:

```
 2) Msf::RPC::RPC_Console#rpc_create supports reading and writing to a console
     Got 0 failures and 3 other errors:

     2.1) Failure/Error: @sock.initialize_abstraction
          
          RuntimeError:
            Error rsock didn't connect in 10 seconds - last child error: Errno::EADDRNOTAVAIL - Can't assign requested address - connect(2) for "127.0.0.1" port 56927

```

Also added a quick test in rex-socket, which shouldn't hang indefinitely:

```
    it 'raises an exception when ulimits are reached' do
      expect do
        100_000.times do |i|
          puts i
          lsock, rsock = described_class.tcp_socket_pair
        end
      end.to raise_exception 'explosion'
    end
```