### PR TITLE
Add the .getresources method for more DNS resolution options

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -270,16 +270,9 @@ module Socket
     return self.rex_getresources(name, typeclass) if @@resolver
 
     typeclass = typeclass.upcase
-    attribute = {
-      CNAME: :name,
-      MX:    :exchange,
-      NS:    :name,
-      PTR:   :name,
-      SOA:   :mname,
-      SRV:   :target
-    }[typeclass]
+    attribute = DNS_RESOURCE_ATTRIBUTE_NAMES[typeclass]
     if attribute.nil?
-      raise ArgumentError, 'Invalid typeclass'
+      raise ArgumentError, "Invalid typeclass: #{typeclass}"
     end
     const = Resolv::DNS::Resource::IN.const_get(typeclass)
 
@@ -1003,16 +996,9 @@ protected
     ) unless name.is_a?(String)
 
     typeclass = typeclass.upcase
-    attribute = {
-      CNAME: :domainname,
-      MX:    :exchange,
-      NS:    :domainname,
-      PTR:   :domainname,
-      SOA:   :mname,
-      SRV:   :target
-    }[typeclass]
+    attribute = REX_DNS_RESOURCE_ATTRIBUTE_NAMES[typeclass]
     if attribute.nil?
-      raise ArgumentError, 'Invalid typeclass'
+      raise ArgumentError, "Invalid typeclass: #{typeclass}"
     end
     const = ::Net::DNS.const_get(typeclass)
 
@@ -1026,6 +1012,26 @@ protected
 
     resources
   end
+
+  DNS_RESOURCE_ATTRIBUTE_NAMES = {
+    CNAME: :name,
+    MX:    :exchange,
+    NS:    :name,
+    PTR:   :name,
+    SOA:   :mname,
+    SRV:   :target
+  }.freeze
+  private_constant :DNS_RESOURCE_ATTRIBUTE_NAMES
+
+  REX_DNS_RESOURCE_ATTRIBUTE_NAMES = {
+    CNAME: :domainname,
+    MX:    :exchange,
+    NS:    :domainname,
+    PTR:   :domainname,
+    SOA:   :mname,
+    SRV:   :target
+  }.freeze
+  private_constant :REX_DNS_RESOURCE_ATTRIBUTE_NAMES
 end
 
 end

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -258,6 +258,14 @@ module Socket
     @@resolver ? self.rex_gethostbyname(host) : ::Socket.gethostbyname(host)
   end
 
+  #
+  # Wrapper for Resolv::DNS.getresources which normalizes the return value to a
+  # list of hostnames regardless of the resource class.
+  #
+  # @param name [String] The name to lookup.
+  # @param typeclass [Symbol] The resource class to lookup, e.g. CNAME, MX, etc.
+  # @raises ArgumentError An argument error is raised when the typeclass is invalid.
+  # @return [Array<String>] The hostnames that were returned by the query.
   def self.getresources(name, typeclass)
     return self.rex_getresources(name, typeclass) if @@resolver
 


### PR DESCRIPTION
This adds a `.getresources` method (named after Ruby's [`Resolv::DNS.getresources`](https://ruby-doc.org/stdlib-2.6.1/libdoc/resolv/rdoc/Resolv/DNS.html#method-i-getresources)) which allows making new DNS queries for records other than the typical A / AAAA. If a resolver is installed from #43, it will be used instead of `Resolv`. This will enable Metasploit to lookup SRV records to identify things like Kerberos and LDAP servers for a domain.

The return value is always an array of strings which are the servers returned by the resource class. This represents a bit of normalization as CNAME, NS, and PTR records all refer to this value in the `name` field while MX uses the `exchange` field etc. This makes some assumptions about what the user wants, mostly that they're looking for a list of hostnames for whatever resource class they're querying. If they want more information like the TTL, the port for SRV records, or the name for SOA records, they'll need to use a different API.

These changes will be necessary for a PR to framework that will alow the `DomainControllerRhost` value to be resolved automatically when using Kerberos authentication.

## Testing

Each record type can be tested using the following code.

```ruby
Rex::Socket.getresources('testing.zonetransfer.me', :CNAME)
Rex::Socket.getresources('gmail.com', :MX)
Rex::Socket.getresources('gmail.com', :NS)
Rex::Socket.getresources('8.8.8.8.in-addr.arpa', :PTR)
Rex::Socket.getresources('gmail.com', :SOA)
Rex::Socket.getresources('_sip._tcp.zonetransfer.me', :SRV)
```

## Example
First without, then with a custom resolver.

```
msf6 exploit(windows/smb/psexec) > pry
[*] Starting Pry shell...
[*] You are in the "exploit/windows/smb/psexec" module object

[1] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('testing.zonetransfer.me', :CNAME)
=> ["www.zonetransfer.me"]
[2] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('gmail.com', :MX)
=> ["alt2.gmail-smtp-in.l.google.com", "gmail-smtp-in.l.google.com", "alt3.gmail-smtp-in.l.google.com", "alt4.gmail-smtp-in.l.google.com", "alt1.gmail-smtp-in.l.google.com"]
[3] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('gmail.com', :NS)
=> ["ns4.google.com", "ns1.google.com", "ns2.google.com", "ns3.google.com"]
[4] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('8.8.8.8.in-addr.arpa', :PTR)
=> ["dns.google"]
[5] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('gmail.com', :SOA)
=> ["ns1.google.com"]
[6] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('_sip._tcp.zonetransfer.me', :SRV)
=> ["www.zonetransfer.me"]
[7] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> resolver = Rex::Proto::DNS::Resolver.new(nameservers: %w[ 127.0.0.53 ])
=> ;; RESOLVER state:
;; config_file: /dev/null 	log_file: /dev/null 	
;; port: 53 	searchlist: [] 	
;; nameservers: ["127.0.0.53"] 	domain: "" 	
;; source_port: 0 	source_address: 0.0.0.0 	
;; retry_interval: 5 	retry_number: 4 	
;; recursive: true 	defname: true 	
;; dns_search: true 	use_tcp: false 	
;; ignore_truncated: false 	packet_size: 512 	
;; tcp_timeout: 30 	udp_timeout: 30 	
;; context:  	comm:  	
;; 
[8] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket._install_global_resolver(resolver)
=> ;; RESOLVER state:
;; config_file: /dev/null 	log_file: /dev/null 	
;; port: 53 	searchlist: [] 	
;; nameservers: ["127.0.0.53"] 	domain: "" 	
;; source_port: 0 	source_address: 0.0.0.0 	
;; retry_interval: 5 	retry_number: 4 	
;; recursive: true 	defname: true 	
;; dns_search: true 	use_tcp: false 	
;; ignore_truncated: false 	packet_size: 512 	
;; tcp_timeout: 30 	udp_timeout: 30 	
;; context:  	comm:  	
;; 
[9] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('testing.zonetransfer.me', :CNAME)
=> ["www.zonetransfer.me"]
[10] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('gmail.com', :MX)
=> ["alt2.gmail-smtp-in.l.google.com", "alt4.gmail-smtp-in.l.google.com", "alt3.gmail-smtp-in.l.google.com", "gmail-smtp-in.l.google.com", "alt1.gmail-smtp-in.l.google.com"]
[11] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('gmail.com', :NS)
=> ["ns2.google.com", "ns1.google.com", "ns3.google.com", "ns4.google.com"]
[12] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('8.8.8.8.in-addr.arpa', :PTR)
=> ["dns.google"]
[13] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('gmail.com', :SOA)
=> ["ns1.google.com"]
[14] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)> Rex::Socket.getresources('_sip._tcp.zonetransfer.me', :SRV)
=> ["www.zonetransfer.me"]
[15] pry(#<Msf::Modules::Exploit__Windows__Smb__Psexec::MetasploitModule>)>
```
