### PR TITLE
Fix .rex_getaddrinfo inconsistencies

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -940,42 +940,30 @@ protected
   # @param resolver [Rex::Proto::DNS::CachedResolver] Resolver to query for the name
   # @return [Array] Array mimicking the native getaddrinfo return type
   def self.rex_getaddrinfo(name, resolver: @@resolver)
-    getaddrinfo = []
+    v4_sockaddrs = []
+    v6_sockaddrs = []
 
     if name =~ /\A\d+\Z/ && name.to_i.between?(0, 0xffffffff)
-      getaddrinfo << Addrinfo.new(
-        self.to_sockaddr(name.to_i, 0),
-        ::Socket::AF_INET,
-        ::Socket::SOCK_STREAM,
-        ::Socket::IPPROTO_TCP
-      )
+      v4_sockaddrs << self.to_sockaddr(name.to_i, 0)
     elsif name =~ /\A0x[0-9a-fA-F]+\Z/ && name.to_i(16).between?(0, 0xffffffff)
-      getaddrinfo << Addrinfo.new(
-        self.to_sockaddr(name.to_i(16), 0),
-        ::Socket::AF_INET,
-        ::Socket::SOCK_STREAM,
-        ::Socket::IPPROTO_TCP
-      )
+      v4_sockaddrs << self.to_sockaddr(name.to_i(16), 0)
+    elsif self.is_ipv4?(name)
+      v4_sockaddrs << self.to_sockaddr(name, 0)
+    elsif self.is_ipv6?(name)
+      v6_sockaddrs << self.to_sockaddr(name, 0)
     else
       v4, v6 = self.rex_resolve_hostname(name, resolver: resolver)
       v4.each do |a4|
-        getaddrinfo << Addrinfo.new(
-          self.to_sockaddr(a4.address.to_s, 0),
-          ::Socket::AF_INET,
-          ::Socket::SOCK_STREAM,
-          ::Socket::IPPROTO_TCP
-        ) unless v4.empty?
+        v4_sockaddrs << self.to_sockaddr(a4.address.to_s, 0)
       end
       v6.each do |a6|
-        getaddrinfo << Addrinfo.new(
-          self.to_sockaddr(a6.address.to_s, 0),
-          ::Socket::AF_INET6,
-          ::Socket::SOCK_STREAM,
-          ::Socket::IPPROTO_TCP
-        ) unless v6.empty?
+        v6_sockaddrs << self.to_sockaddr(a6.address.to_s, 0)
       end
     end
-    getaddrinfo
+
+    (v4_sockaddrs.map { |sa| [sa, ::Socket::AF_INET] } + v6_sockaddrs.map { |sa| [sa, ::Socket::AF_INET6] }).map do |sa, family|
+      Addrinfo.new(sa, family, ::Socket::SOCK_STREAM, ::Socket::IPPROTO_TCP)
+    end
   end
 
 

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -942,14 +942,14 @@ protected
   def self.rex_getaddrinfo(name, resolver: @@resolver)
     getaddrinfo = []
 
-    if name =~ /^\d+$/ && name.to_i.between?(0, 0xffffffff)
+    if name =~ /\A\d+\Z/ && name.to_i.between?(0, 0xffffffff)
       getaddrinfo << Addrinfo.new(
         self.to_sockaddr(name.to_i, 0),
         ::Socket::AF_INET,
         ::Socket::SOCK_STREAM,
         ::Socket::IPPROTO_TCP
       )
-    elsif name =~ /^0x[0-9a-fA-F]+$/ && name.to_i(16).between?(0, 0xffffffff)
+    elsif name =~ /\A0x[0-9a-fA-F]+\Z/ && name.to_i(16).between?(0, 0xffffffff)
       getaddrinfo << Addrinfo.new(
         self.to_sockaddr(name.to_i(16), 0),
         ::Socket::AF_INET,

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -4,6 +4,7 @@ require 'socket'
 require 'thread'
 require 'resolv'
 require 'rex/exceptions'
+require 'dnsruby'
 
 module Rex
 
@@ -974,21 +975,21 @@ protected
     ) unless name.is_a?(String)
     # Pull both record types
     v4 = begin
-      resolver.send(name, ::Net::DNS::A).answer.select do |a|
+      resolver.send(name, ::Dnsruby::Types::A).answer.select do |a|
         a.type == Dnsruby::Types::A
       end.sort_by do |a|
         self.addr_ntoi(a.address.address)
       end
-    rescue
+    rescue StandardError
       []
     end
     v6 = begin
-      resolver.send(name, ::Net::DNS::AAAA).answer.select do |a|
+      resolver.send(name, Dnsruby::Types::AAAA).answer.select do |a|
         a.type == Dnsruby::Types::AAAA
       end.sort_by do |a|
         self.addr_ntoi(a.address.address)
       end
-    rescue
+    rescue StandardError
       []
     end
     # Emulate ::Socket's error if no responses found
@@ -1012,7 +1013,7 @@ protected
     if attribute.nil?
       raise ArgumentError, "Invalid typeclass: #{typeclass}"
     end
-    const = ::Net::DNS.const_get(typeclass)
+    const = Dnsruby::Types.const_get(typeclass)
 
     resources = begin
       resolver.send(name, const).answer.select do |a|

--- a/rex-socket.gemspec
+++ b/rex-socket.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
 
   spec.add_runtime_dependency "rex-core"
+  spec.add_runtime_dependency "dnsruby"
 end

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -207,6 +207,10 @@ RSpec.describe Rex::Socket do
         expect(mock_resolver).not_to receive(:send)
       end
 
+      after(:each) do
+        described_class._install_global_resolver(nil)
+      end
+
       context 'when passed in a decimal hostname' do
         let(:hostname) { '0' }
         let(:response_addresses) { ['0.0.0.0'] }
@@ -419,5 +423,75 @@ RSpec.describe Rex::Socket do
          expect(name).to eq true
        end
      end
+  end
+
+  describe '.rex_getaddrinfo' do
+    subject(:addrinfos) do
+      described_class.rex_getaddrinfo(hostname)
+    end
+
+    context 'with a hostname' do
+      let(:hostname) { 'localhost' }
+      it 'should call .rex_resolve_hostname' do
+        expect(described_class).to receive(:rex_resolve_hostname).with(hostname, {resolver: nil}).and_return([ [], [] ])
+        subject
+      end
+
+      it 'should return IPv4 and IPv6 addresses' do
+        expect(described_class).to receive(:rex_resolve_hostname).and_return([
+          [Dnsruby::RR::IN::A.new(address: '127.0.0.1')],
+          [Dnsruby::RR::IN::AAAA.new(address: '::1')]
+        ])
+
+        expect(subject).to match_array([
+          have_attributes(ip_address: '127.0.0.1', afamily: ::Socket::AF_INET, socktype: ::Socket::SOCK_STREAM, protocol: ::Socket::IPPROTO_TCP),
+          have_attributes(ip_address: '::1', afamily: ::Socket::AF_INET6, socktype: ::Socket::SOCK_STREAM, protocol: ::Socket::IPPROTO_TCP)
+        ])
+      end
+    end
+
+    context 'with a decimal name' do
+      let(:hostname) { '255' }
+      it 'should not call .rex_resolve_hostname' do
+        expect(described_class).to_not receive(:rex_resolve_hostname)
+        subject
+      end
+
+      it 'should return one IPv4 address' do
+        expect(subject).to match_array([
+          have_attributes(ip_address: '0.0.0.255', afamily: ::Socket::AF_INET, socktype: ::Socket::SOCK_STREAM, protocol: ::Socket::IPPROTO_TCP),
+        ])
+      end
+    end
+
+    context 'with an invalid decimal name' do
+      let(:hostname) { '4294967296' }
+      it 'should call .rex_resolve_hostname' do
+        expect(described_class).to receive(:rex_resolve_hostname).with(hostname, {resolver: nil}).and_raise(::SocketError.new('getaddrinfo: Name or service not known'))
+        expect { subject }.to raise_error(::SocketError)
+      end
+    end
+
+    context 'with a hexadecimal name' do
+      let(:hostname) { '0xff' }
+      it 'should not call .rex_resolve_hostname' do
+        expect(described_class).to_not receive(:rex_resolve_hostname)
+        subject
+      end
+
+      it 'should return one IPv4 address' do
+        expect(subject).to match_array([
+          have_attributes(ip_address: '0.0.0.255', afamily: ::Socket::AF_INET, socktype: ::Socket::SOCK_STREAM, protocol: ::Socket::IPPROTO_TCP),
+        ])
+      end
+    end
+
+    context 'with an invalid hexadecimal name' do
+      let(:hostname) { '0x100000000' }
+      it 'should call .rex_resolve_hostname' do
+        expect(described_class).to receive(:rex_resolve_hostname).with(hostname, {resolver: nil}).and_raise(::SocketError.new('getaddrinfo: Name or service not known'))
+        expect { subject }.to raise_error(::SocketError)
+      end
+    end
   end
 end

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -198,6 +198,37 @@ RSpec.describe Rex::Socket do
 
       it { expect { subject }.to raise_exception(::SocketError, 'getaddrinfo: nodename nor servname provided, or not known') }
     end
+
+    context 'when passed in a numeric hostname' do
+      let(:mock_resolver) { double('Resolver', send: nil) }
+
+      before(:each) do
+        described_class._install_global_resolver(mock_resolver)
+        expect(mock_resolver).not_to receive(:send)
+      end
+
+      context 'when passed in a decimal hostname' do
+        let(:hostname) { '0' }
+        let(:response_addresses) { ['0.0.0.0'] }
+
+        it { is_expected.to be_an(Array) }
+        it { expect(subject.size).to eq(1) }
+        it "should return the ASCII addresses" do
+          expect(subject).to include("0.0.0.0")
+        end
+      end
+
+      context 'when passed in a decimal hostname' do
+        let(:hostname) { '0x0' }
+        let(:response_addresses) { ['0.0.0.0'] }
+
+        it { is_expected.to be_an(Array) }
+        it { expect(subject.size).to eq(1) }
+        it "should return the ASCII addresses" do
+          expect(subject).to include("0.0.0.0")
+        end
+      end
+    end
   end
 
   describe '.portspec_to_portlist' do

--- a/spec/rex/socket_spec.rb
+++ b/spec/rex/socket_spec.rb
@@ -450,6 +450,34 @@ RSpec.describe Rex::Socket do
       end
     end
 
+    context 'with an IPv4 name' do
+      let(:hostname) { '127.0.0.1' }
+      it 'should not call .rex_resolve_hostname' do
+        expect(described_class).to_not receive(:rex_resolve_hostname)
+        subject
+      end
+
+      it 'should return one IPv4 address' do
+        expect(subject).to match_array([
+          have_attributes(ip_address: '127.0.0.1', afamily: ::Socket::AF_INET, socktype: ::Socket::SOCK_STREAM, protocol: ::Socket::IPPROTO_TCP),
+        ])
+      end
+    end
+
+    context 'with an IPv6 name' do
+      let(:hostname) { '::1' }
+      it 'should not call .rex_resolve_hostname' do
+        expect(described_class).to_not receive(:rex_resolve_hostname)
+        subject
+      end
+
+      it 'should return one IPv6 address' do
+        expect(subject).to match_array([
+          have_attributes(ip_address: '::1', afamily: ::Socket::AF_INET6, socktype: ::Socket::SOCK_STREAM, protocol: ::Socket::IPPROTO_TCP),
+        ])
+      end
+    end
+
     context 'with a decimal name' do
       let(:hostname) { '255' }
       it 'should not call .rex_resolve_hostname' do


### PR DESCRIPTION
The `.rex_getaddrinfo` method behaves inconsistently with `Addrinfo.getaddrinfo`, which makes `.getaddresses`  inconsistent depending on if a resolver is present or not. When no resolver is present, a numeric address (either decimal or hex, not binary or octal) is specified, it's converted to an IPv4 address:

```
[2] pry(#<Msf::Modules::Exploit__Multi__Ssh__Sshexec::MetasploitModule>)> ::Addrinfo.getaddrinfo('0', 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM)
=> [#<Addrinfo: 0.0.0.0 TCP (0)>]
```

But when a resolver is present, `.getaddresses` will call `.rex_getaddrinfo` and it falls with a resolution error because the address is not a valid hostname:

```
[10] pry(#<Msf::Modules::Exploit__Multi__Ssh__Sshexec::MetasploitModule>)> Rex::Socket.rex_getaddrinfo('0')
SocketError: getaddrinfo: Name or service not known
from /home/smcintyre/.rvm/gems/ruby-3.1.5@metasploit-framework/gems/rex-socket-0.1.57/lib/rex/socket.rb:996:in `rex_resolve_hostname'
[11] pry(#<Msf::Modules::Exploit__Multi__Ssh__Sshexec::MetasploitModule>)>
```

This came up as an issue that prevents Metasploit's route command from working when invoked as `route add 0 0 -1` to add a default route for all IPv4 addresses through the most recent session when the DNS feature is enabled. This also removes references to `::Net::DNS` in favor of using the constants from `Dnsruby::Types` instead, which was already referenced but not defined as a requirement. Adding Dnsruby as a requirement was needed to make the tests work.