### PR TITLE
Update github pipeline

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,10 +37,11 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         os:
           - ubuntu-20.04
           - windows-2019
-          - macos-11
+          - macos-13
           - ubuntu-latest
         exclude:
           - { os: ubuntu-latest, ruby: '2.7' }


### PR DESCRIPTION
Update the github pipeline  versions as macos-11 is end of life, and hangs indefinitely if you try to use it