### PR TITLE
Use custom resolver when creating the socket

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -262,7 +262,7 @@ class Rex::Socket::Comm::Local
         end
 
         ip6_scope_idx = 0
-        ip   = param.peerhost
+        ip   = Rex::Socket.getaddress(param.peerhost)
         port = param.peerport
 
         if param.proxies


### PR DESCRIPTION
The custom DNS resolution rules are inconsistently applied. They are respected for the purpose of choosing a communication channel (`SwitchBoard::best_comm`), but then when it does the resolution itself, it ignores it. One place where this occurs is within `Rex::Proto::Http::Client`. Setting `rhost` to a domain name (instead of an IP) will initially figure out the `comm` by doing DNS resolution using Metasploit's custom DNS resolver; but then when it goes to actually do the request over that `comm` channel, it eventually just calls `Socket::pack_sockaddr_in` with our `rhost` domain name, which just uses the system

## Concern

This fix may have issues with Socks proxies, in which case we shouldn't be doing our own resolution... but it looks like there's already a ticket for this (https://github.com/rapid7/rex-socket/issues/70).

## Reproduction Steps

The easiest way to observe the effect of this issue is with static rules:

- Start with a clean configuration (`dns reset-config`)
- Delete all of metasploit's DNS configs (`dns remove -i 1`)
- Add the static resolver back in (`dns add static`)
- Remove all static entries (`dns flush-static`)
- Make sure it's a clean test: `dns flush-cache`
- Add a single static entry pointing `google.com` to the wrong IP (`dns add-static google.com 1.2.3.4`)
- `irb`
- `send_request_cgi({'rhost'=>'google.com','rport'=>80,'url'=>'/'})`
- Prior to this fix, this should actually end up reaching out to the real google server. You'll see the result's peerinfo be pointing at the real google address. The expected behaviour is that it should hang (and eventually return `nil`), since we overrode the IP using our custom DNS.

For a more realistic scenario, set up a DNS server with a private DNS zone. My example is `*.sccm.lab`. Set up an HTTP server on a host within that DNS zone (mine is `mecm.sccm.lab`) Ensure this DNS server is not used by the underlying OS for its DNS resolution (so `dig validHost.private.zone` should fail, but `dig @privateDnsServer validHost.private.zone` succeeds). There are probably ways to simplify the reproduction steps, but this is the use case I encountered the issue with.

- Start with a clean configuration (`dns reset-config`)
- Delete all of metasploit's DNS configs (`dns remove -i 1`)
- Remove all static entries (`dns flush-static`)
- Make sure it's a clean test: `dns flush-cache`
- Add a dns resolver to our private DNS server: `dns add --rule *.sccm.lab <privateDnsServer>`
- `irb`
- `send_request_cgi({'rhost'=>'mecm.sccm.lab','rport'=>80,'url'=>'/'})`
- Prior to this fix, this would fail (`rex-socket/lib/rex/socket.rb:306:in `pack_sockaddr_in': getaddrinfo: Name or service not known (SocketError)`). Following the fix, it should work.

Now with static entries:
- Start with a clean configuration (`dns reset-config`)
- Delete all of metasploit's DNS configs (`dns remove -i 1`)
- Add the static resolver back in (`dns add static`)
- Remove all static entries (`dns flush-static`)
- Make sure it's a clean test: `dns flush-cache`
- Add a single static entry pointing `mecm.sccm.lab` to the correct IP (`dns add-static mecm.sccm.lab <the IP>`)
- `irb`
- `send_request_cgi({'rhost'=>'mecm.sccm.lab','rport'=>80,'url'=>'/'})`
- Prior to this fix, this would fail. Following the fix, it should work.
