### PR TITLE
Adds enhanced support for network capture decryption

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -805,6 +805,7 @@ module Socket
     if (params)
       self.peerhost  = params.peerhost
       self.peerhostname = params.peerhostname
+      self.sslkeylogfile = params.sslkeylogfile
       self.peerport  = params.peerport
       self.localhost = params.localhost
       self.localport = params.localport
@@ -888,6 +889,10 @@ module Socket
   #
   attr_reader :peerhostname
   #
+  # The SSL key log file path.
+  #
+  attr_reader :sslkeylogfile
+  #
   # The peer port of the connected socket.
   #
   attr_reader :peerport
@@ -912,7 +917,7 @@ module Socket
 
 protected
 
-  attr_writer :peerhost, :peerhostname, :peerport, :localhost, :localport # :nodoc:
+  attr_writer :peerhost, :peerhostname, :sslkeylogfile, :peerport, :localhost, :localport # :nodoc:
   attr_writer :context # :nodoc:
   attr_writer :ipv # :nodoc:
 

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -51,6 +51,8 @@ class Rex::Socket::Parameters
   #
   # @option hash [String] 'PeerHost' The remote host to connect to
   # @option hash [String] 'PeerHostname' The unresolved remote hostname, used to specify Server Name Indication (SNI)
+  # @option hash [String] 'SSLKeyLogFile' The SSL key log file path, used for network capture
+  #   decryption which is useful to decrypt TLS traffic in wireshark
   # @option hash [String] 'PeerAddr' (alias for 'PeerHost')
   # @option hash [Fixnum] 'PeerPort' The remote port to connect to
   # @option hash [String] 'LocalHost' The local host to communicate from, if any
@@ -114,6 +116,10 @@ class Rex::Socket::Parameters
 
     if hash['SSLContext']
       self.sslctx = hash['SSLContext']
+    end
+
+    if (hash['SSLKeyLogFile'])
+      self.sslkeylogfile = hash['SSLKeyLogFile']
     end
 
     self.ssl_version = hash.fetch('SSLVersion', nil)
@@ -301,6 +307,11 @@ class Rex::Socket::Parameters
   # key.
   # @return [String]
   attr_accessor :peerhostname
+
+  # The SSL key log file path, equivalent to the sslkeylogfile parameter hash
+  # key.
+  # @return [String]
+  attr_accessor :sslkeylogfile
 
   # The remote port.  Equivalent to the PeerPort parameter hash key.
   # @return [Fixnum]

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -84,8 +84,6 @@ begin
     # Build the SSL connection
     self.sslctx  = OpenSSL::SSL::SSLContext.new(version)
 
-    sslkeylogfile = ENV.fetch('SSLKEYLOGFILE', nil)
-
     # writing to the sslkeylogfile is required, it adds support for network capture decryption which is useful to
     # decrypt TLS traffic in wireshark
     if sslkeylogfile


### PR DESCRIPTION
This pull request adds enhanced support for network capture decryption. By writing to the sslkeylogfile it enable network capture decryption which is useful to decrypt TLS traffic in wireshark. 

Needs tested with Metasploit-Framework, to do this add the following to the Metasploit-Framework Gemfile:
```
gem "rex-socket", path: "../rex-socket"
```

Then `bundle install`.

## Verification
- [ ] Start msfconsole
- [ ] Use `scanner/http/title`
- [ ] Run `run rhosts=https://www.google.com verbose=true httptrace=true sslkeylogfile=./sslkeylogfile.txt`
- [ ] The module should complete
- [ ] Run `ls -la` and you should now see a file called `sslkeylogfile.txt`