### PR TITLE
Add SOCKS5H Support

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -262,14 +262,15 @@ class Rex::Socket::Comm::Local
         end
 
         ip6_scope_idx = 0
-        ip   = Rex::Socket.getaddress(param.peerhost)
-        port = param.peerport
 
         if param.proxies
           chain = param.proxies.dup
           chain.push(['host',param.peerhost,param.peerport])
-          ip = chain[0][1]
+          ip   = chain[0][1]
           port = chain[0][2].to_i
+        else
+          ip   = Rex::Socket.getaddress(param.peerhost)
+          port = param.peerport
         end
 
         begin
@@ -326,12 +327,13 @@ class Rex::Socket::Comm::Local
         end
       end
 
+      # fixme: handle the chain object here
       if chain.size > 1
         chain.each_with_index {
           |proxy, i|
           next_hop = chain[i + 1]
           if next_hop
-            proxy(sock, proxy[0], next_hop[1], next_hop[2])
+            proxy(sock, proxy[0], next_hop[1], next_hop[2].to_i)
           end
         }
       end
@@ -342,8 +344,6 @@ class Rex::Socket::Comm::Local
         sock.extend(klass)
         sock.initsock(param)
       end
-
-
     end
 
     # Notify handlers that a socket has been created.

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -424,10 +424,11 @@ class Rex::Socket::Comm::Local
         raise Rex::ConnectionProxyError.new(host, port, type, "Failed to receive a response from the proxy"), caller
       end
 
-      resp = Rex::Proto::Http::Response.new
-      resp.update_cmd_parts(ret.split(/\r?\n/)[0])
+      if (match = ret.match(/HTTP\/.+?\s+(\d+)\s?.+?\r?\n?$/))
+        status_code  = match[1].to_i
+      end
 
-      if resp.code != 200
+      if status_code != 200
         raise Rex::ConnectionProxyError.new(host, port, type, "The proxy returned a non-OK response"), caller
       end
     when Rex::Socket::Proxies::ProxyType::SOCKS4

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -312,6 +312,7 @@ class Rex::Socket::Parameters
   # The local host.  Equivalent to the LocalHost parameter hash key.
   # @return [String]
   attr_writer :localhost
+
   def localhost
     return @localhost if @localhost
 
@@ -354,7 +355,9 @@ class Rex::Socket::Parameters
     best_comm = nil
     # If no comm was explicitly specified, try to use the comm that is best fit
     # to handle the provided host based on the current routing table.
-    if server and localhost
+    if proxies?
+      best_comm = Rex::Socket::Comm::Local
+    elsif server && localhost
       best_comm = Rex::Socket::SwitchBoard.best_comm(localhost)
     elsif peerhost
       best_comm =  Rex::Socket::SwitchBoard.best_comm(peerhost)
@@ -471,6 +474,10 @@ class Rex::Socket::Parameters
   # List of proxies to use
   # @return [Array]
   attr_accessor :proxies
+
+  def proxies?
+    proxies && !proxies.empty?
+  end
 
   alias peeraddr  peerhost
   alias localaddr localhost

--- a/lib/rex/socket/proxies.rb
+++ b/lib/rex/socket/proxies.rb
@@ -8,6 +8,7 @@ module Rex
         HTTP = 'http'
         SOCKS4 = 'socks4'
         SOCKS5 = 'socks5'
+        SOCKS5H = 'socks5h'
       end
 
       # @param [String,nil] value A proxy chain of format {type:host:port[,type:host:port][...]}

--- a/lib/rex/socket/proxies.rb
+++ b/lib/rex/socket/proxies.rb
@@ -12,9 +12,37 @@ module Rex
       end
 
       # @param [String,nil] value A proxy chain of format {type:host:port[,type:host:port][...]}
-      # @return [Array] The array of proxies, i.e. {[['type', 'host', 'port']]}
+      # @return [Array<URI>] The array of proxies
       def self.parse(value)
-        value.to_s.strip.split(',').map { |a| a.strip }.map { |a| a.split(':').map { |b| b.strip } }
+        proxies = []
+        value.to_s.strip.split(',').each do |proxy|
+          proxy = proxy.strip
+
+          # replace the first : with :// so it can be parsed as a URI
+          # URIs will offer more flexibility long term, but we'll keep backwards compatibility for now by treating : as ://
+          proxy = proxy.sub(/\A(\w+):(\w+)/, '\1://\2')
+          uri = URI(proxy)
+
+          unless supported_types.include?(uri.scheme)
+            raise Rex::RuntimeError.new("Unsupported proxy scheme: #{uri.scheme}")
+          end
+
+          if uri.host.nil? || uri.host.empty?
+            raise Rex::RuntimeError.new("A proxy URI must include a valid host.")
+          end
+
+          if uri.port.nil? && uri.scheme.start_with?('socks')
+            uri.port = 1080
+          end
+
+          if uri.port.nil? || uri.port.zero?
+            raise Rex::RuntimeError.new("A proxy URI must include a valid port.")
+          end
+
+          proxies << uri
+        end
+
+        proxies
       end
 
       def self.supported_types

--- a/spec/rex/socket/comm/local_spec.rb
+++ b/spec/rex/socket/comm/local_spec.rb
@@ -34,12 +34,76 @@ RSpec.describe Rex::Socket::Comm::Local do
     context 'with proxies set' do
       let(:params) { Rex::Socket::Parameters.new({ 'PeerHost' => '192.0.2.1', 'PeerPort' => 1234, 'Proxies' => 'http:192.0.2.2:8080, socks5:192.0.2.3:1080' }) }
 
+      it 'does not resolve the hostname' do
+        expect(Rex::Socket).to_not receive(:getaddresses)
+      end
+
       it 'connects to the target through a proxy' do
         expect(sock).to receive(:connect).with(Rex::Socket.to_sockaddr('192.0.2.2', 8080)).and_return(nil)
 
         expect(described_class).to receive(:proxy).with(sock, 'http', '192.0.2.3', 1080).and_return(nil).ordered
         expect(described_class).to receive(:proxy).with(sock, 'socks5', params.peerhost, params.peerport).and_return(nil).ordered
         described_class.create_by_type(params, type, proto)
+      end
+    end
+  end
+
+  describe '.proxy' do
+    let(:sock) { RSpec::Mocks::Double.new('socket') }
+    let(:host) { '192.0.2.1' }
+    let(:port) { 8080 }
+
+    context 'when type is http' do
+      let(:type) { 'http' }
+
+      it 'connects via HTTP' do
+        data = "CONNECT #{host}:#{port} HTTP/1.0\r\n\r\n"
+        expect(sock).to receive(:put).with(data).and_return(data.length)
+        expect(sock).to receive(:get_once).and_return("HTTP/1.1 200 Connection Established\r\n\r\n")
+        described_class.proxy(sock, type, host, port)
+      end
+    end
+
+    context 'when type is invalid' do
+      let(:type) { 'invalid' }
+
+      it 'raises an error' do
+        expect {
+          described_class.proxy(sock, type, host, port)
+        }.to raise_error(RuntimeError, /proxy type specified is not valid/)
+      end
+    end
+
+    context 'when type is socks4' do
+      let(:type) { 'socks4' }
+      let(:host) { 'localhost' }
+
+      it 'resolves the hostname to an address' do
+        expect(Rex::Socket).to receive(:getaddress).with(host, false).and_return('127.0.0.1')
+        expect(described_class).to receive(:proxy_socks4a).with(sock, type, '127.0.0.1', port)
+        described_class.proxy(sock, type, host, port)
+      end
+    end
+
+    context 'when type is socks5' do
+      let(:type) { 'socks5' }
+      let(:host) { 'localhost' }
+
+      it 'resolves the hostname to an address' do
+        expect(Rex::Socket).to receive(:getaddress).with(host, Rex::Socket.support_ipv6?).and_return('127.0.0.1')
+        expect(described_class).to receive(:proxy_socks5h).with(sock, type, '127.0.0.1', port)
+        described_class.proxy(sock, type, host, port)
+      end
+    end
+
+    context 'when type is socks5h' do
+      let(:type) { 'socks5h' }
+      let(:host) { 'localhost' }
+
+      it 'does not resolve the hostname to an address' do
+        expect(Rex::Socket).to_not receive(:getaddress)
+        expect(described_class).to receive(:proxy_socks5h).with(sock, type, host, port)
+        described_class.proxy(sock, type, host, port)
       end
     end
   end

--- a/spec/rex/socket/comm/local_spec.rb
+++ b/spec/rex/socket/comm/local_spec.rb
@@ -1,0 +1,46 @@
+# -*- coding:binary -*-
+require 'rex/socket/parameters'
+
+RSpec.describe Rex::Socket::Comm::Local do
+  describe '.create_by_type' do
+    let(:type) { ::Socket::SOCK_STREAM }
+    let(:proto) { ::Socket::IPPROTO_TCP }
+    let(:params) { Rex::Socket::Parameters.new({ 'PeerHost' => '192.0.2.1', 'PeerPort' => 1234 }) }
+    let(:sock) { RSpec::Mocks::Double.new('socket') }
+
+    before(:each) do
+      allow(Rex::Socket).to receive(:support_ipv6?).with(no_args).and_return(true)
+      allow(::Socket).to receive(:new).with(any_args).and_return(sock)
+      allow(sock).to receive(:setsockopt).with(any_args)
+      allow(sock).to receive(:bind).with(any_args)
+      allow(sock).to receive(:connect).with(any_args).and_return(nil)
+    end
+
+    it 'creates an IPv4 socket' do
+      expect(::Socket).to receive(:new).with(::Socket::AF_INET, type, proto).and_return(sock)
+      described_class.create_by_type(params, type, proto)
+    end
+
+    it 'connects the new socket' do
+      expect(sock).to receive(:connect).with(Rex::Socket.to_sockaddr(params.peerhost, params.peerport)).and_return(nil)
+      described_class.create_by_type(params, type, proto)
+    end
+
+    it 'connects directly to the target' do
+      expect(described_class).to_not receive(:proxy)
+      described_class.create_by_type(params, type, proto)
+    end
+
+    context 'with proxies set' do
+      let(:params) { Rex::Socket::Parameters.new({ 'PeerHost' => '192.0.2.1', 'PeerPort' => 1234, 'Proxies' => 'http:192.0.2.2:8080, socks5:192.0.2.3:1080' }) }
+
+      it 'connects to the target through a proxy' do
+        expect(sock).to receive(:connect).with(Rex::Socket.to_sockaddr('192.0.2.2', 8080)).and_return(nil)
+
+        expect(described_class).to receive(:proxy).with(sock, 'http', '192.0.2.3', 1080).and_return(nil).ordered
+        expect(described_class).to receive(:proxy).with(sock, 'socks5', params.peerhost, params.peerport).and_return(nil).ordered
+        described_class.create_by_type(params, type, proto)
+      end
+    end
+  end
+end

--- a/spec/rex/socket/parameters_spec.rb
+++ b/spec/rex/socket/parameters_spec.rb
@@ -106,11 +106,11 @@ RSpec.describe Rex::Socket::Parameters do
 
     it 'should handle new proxy definitions' do
       expect(params.proxies).to eq nil
-      new_params = params.merge({ 'Proxies' => '1.2.3.4:1234, 5.6.7.8:5678' })
+      new_params = params.merge({ 'Proxies' => 'http:1.2.3.4:1234, http:5.6.7.8:5678' })
       expect(params.proxies).to eq nil
       expect(new_params.proxies).to eq [
-        ['1.2.3.4', '1234'],
-        ['5.6.7.8', '5678']
+        URI('http://1.2.3.4:1234'),
+        URI('http://5.6.7.8:5678')
       ]
     end
   end

--- a/spec/rex/socket/proxies_spec.rb
+++ b/spec/rex/socket/proxies_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Rex::Socket::Proxies do
         socks4
         http
         socks5
+        socks5h
       ]
       expect(subject.supported_types).to match_array expected
     end

--- a/spec/rex/socket/proxies_spec.rb
+++ b/spec/rex/socket/proxies_spec.rb
@@ -1,4 +1,5 @@
 # -*- coding:binary -*-
+require 'uri'
 require 'rex/socket/proxies'
 
 RSpec.describe Rex::Socket::Proxies do
@@ -20,7 +21,12 @@ RSpec.describe Rex::Socket::Proxies do
       { value: nil, expected: [] },
       { value: '', expected: [] },
       { value: '           ', expected: [] },
-      { value: 'sapni:198.51.100.1:8080,       socks4:198.51.100.1:1080      ', expected: [['sapni', '198.51.100.1', '8080'], ['socks4', '198.51.100.1', '1080']] },
+      { value: 'http://localhost', expected: [URI('http://localhost:80')]},
+      { value: 'http:localhost:8080', expected: [URI('http://localhost:8080')]},
+      { value: 'socks4://localhost', expected: [URI('socks4://localhost:1080')] },
+      { value: 'socks5://localhost', expected: [URI('socks5://localhost:1080')] },
+      { value: 'socks5h://localhost', expected: [URI('socks5h://localhost:1080')] },
+      { value: 'sapni:198.51.100.1:8080,       socks4:198.51.100.1:1080      ', expected: [URI('sapni://198.51.100.1:8080'), URI('socks4://198.51.100.1:1080')] },
     ].each do |test|
       it "correctly parses #{test[:value]} as #{test[:expected]}" do
         expect(described_class.parse(test[:value])).to eq test[:expected]


### PR DESCRIPTION
This adds SOCKS5H support to Rex::Socket, allowing TCP connections established with the local comm to be made through SOCKS5 proxies. The difference between SOCKS5 and SOCKS5H is where hostnames are resolved to DNS. There is a common convention where SOCKS5 proxy clients (including Metasploit) resolve hostnames themselves and issue the IP address to the SOCKS server when connecting. SOCKS5H on the other hand is an unofficial standard whereby the hostname is passed to the SOCKS server, allowing it to be resolved by the proxy instead of Metasploit. 

These changes lay the ground work for Metasploit to support both conventions. There will be a PR to rapid7/metasploit-framework shortly that will take advantage of these changes.

This PR also adds a number of unit tests to show how proxies are handled and ensure resolution does and does not happen when appropriate.

## Proxy Strings
Proxies are now parsed into URI instances instead of arrays. This means Ruby's builtin `URI` class and it's parsing capabilities can be leveraged instead of using a custom solution. In the future this should also allow additional options to be specified in the URI, so if an HTTP proxy requires authentication, it can be specified in the URI. The `//` part of the URi is optional to ensure backwards compatibility, e.g. `http:localhost:8080` will still work but it's normalized to `http://localhost:8080` under the hood so it can be processed as a URI.

## Test Script
This test script will target an SSH server on TCP port 22 which works well as a test case because SSH will send it's banner, showing that the connection was established. This script allows a proxy to be set so a user can interactively observe how their options affect the socket creation. Use wireshark to check the connect request made to the SOCKS server to see if a hostname or IP address was sent.

```ruby
$LOAD_PATH.unshift 'lib'
require 'optparse'
require 'rex/socket'

options = {}
parser = OptionParser.new do |opts|
  opts.banner = "Usage: script.rb TARGET [--proxy PROXY]"

  opts.on("--proxy PROXY", String, "Proxy (optional)") do |proxy|
    options[:proxy] = proxy
  end
end

begin
  parser.parse!
  raise OptionParser::MissingArgument, "TARGET is required" if ARGV.empty?
  options[:target] = ARGV.shift
rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
  puts e.message
  puts parser
  exit 1
end

puts "Target: #{options[:target]}"
puts "Proxy:  #{options[:proxy]}" if options[:proxy]

client = Rex::Socket::Tcp.create({
  'PeerHost' => options[:target],
  'PeerPort' => 22,
  'SSL'      => false,
  'Proxies'  => options[:proxy]
})
data = client.get_once

$stderr.puts data
client.close
```