### PR TITLE
Add `Interface` socket option for binding to a network interface

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -242,7 +242,7 @@ class Rex::Socket::Comm::Local
           sock.close
           raise
         end
-      elsif Rex::Compat.is_osx && defined?(::Socket::IP_BOUND_IF)
+      elsif Rex::Compat.is_macosx && defined?(::Socket::IP_BOUND_IF)
         begin
           idx = ::Socket.getifaddrs.find { |ifaddr| ifaddr.name == param.interface }&.ifindex
           if idx.nil?

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -207,25 +207,8 @@ class Rex::Socket::Comm::Local
       sock = ::Socket.new(::Socket::AF_INET, type, proto)
     end
 
-    # Bind to a given local address and/or port if they are supplied
-    if param.localport || param.localhost
-      begin
-
-        # SO_REUSEADDR has undesired semantics on Windows, instead allowing
-        # sockets to be stolen without warning from other unprotected
-        # processes.
-        unless Rex::Compat.is_windows
-          sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, true)
-        end
-
-        sock.bind(Rex::Socket.to_sockaddr(param.localhost, param.localport))
-
-      rescue ::Errno::EADDRNOTAVAIL,::Errno::EADDRINUSE
-        sock.close
-        raise Rex::BindFailed.new(param.localhost, param.localport), caller
-      end
-    end
-
+    # Apply interface binding BEFORE sock.bind() so the socket appears in netstat
+    # and accepts connections on the specified interface
     if param.interface && !param.interface.empty?
       if Rex::Compat.is_linux
         begin
@@ -267,6 +250,25 @@ class Rex::Socket::Comm::Local
         sock.close
         raise Rex::BindFailed.new(param.localhost, param.localport,
           reason: 'Interface binding is not supported on this platform'), caller
+      end
+    end
+
+    # Bind to a given local address and/or port if they are supplied
+    if param.localport || param.localhost
+      begin
+
+        # SO_REUSEADDR has undesired semantics on Windows, instead allowing
+        # sockets to be stolen without warning from other unprotected
+        # processes.
+        unless Rex::Compat.is_windows
+          sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, true)
+        end
+
+        sock.bind(Rex::Socket.to_sockaddr(param.localhost, param.localport))
+
+      rescue ::Errno::EADDRNOTAVAIL,::Errno::EADDRINUSE
+        sock.close
+        raise Rex::BindFailed.new(param.localhost, param.localport), caller
       end
     end
 

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -163,6 +163,33 @@ class Rex::Socket::Comm::Local
         reason: 'Interface option is incompatible with proxy use'), caller
     end
 
+    if param.interface && !param.interface.empty? && Rex::Compat.is_windows
+      iface_ip = nil
+      iface_found = false
+      begin
+        ::Socket.getifaddrs.each do |ifaddr|
+          next unless ifaddr.name == param.interface
+          iface_found = true
+          next unless ifaddr.addr&.ipv4?
+          iface_ip = ifaddr.addr.ip_address
+          break
+        end
+      rescue ::SystemCallError, ::SocketError => e
+        raise Rex::BindFailed.new(param.localhost, param.localport,
+          reason: "Failed to enumerate interfaces: #{e.message}"), caller
+      end
+      if iface_ip.nil?
+        reason = if iface_found
+          "Interface #{param.interface} has no IPv4 address"
+        else
+          "Interface #{param.interface} not found"
+        end
+        raise Rex::BindFailed.new(param.localhost, param.localport,
+          reason: reason), caller
+      end
+      param.localhost = iface_ip
+    end
+
     # Create the socket
     sock = nil
     if param.v6
@@ -202,25 +229,31 @@ class Rex::Socket::Comm::Local
           sock.close
           raise Rex::BindFailed.new(param.localhost, param.localport,
             reason: "Binding to interface #{param.interface} requires elevated privileges"), caller
+        rescue ::SystemCallError
+          sock.close
+          raise
         end
       elsif Rex::Compat.is_osx && defined?(::Socket::IP_BOUND_IF)
         begin
-          idx = ::Socket.if_nametoindex(param.interface)
+          idx = ::Socket.getifaddrs.find { |ifaddr| ifaddr.name == param.interface }&.ifindex
+          if idx.nil?
+            sock.close
+            raise Rex::BindFailed.new(param.localhost, param.localport,
+              reason: "Interface #{param.interface} not found"), caller
+          end
           sock.setsockopt(::Socket::IPPROTO_IP, ::Socket::IP_BOUND_IF, [idx].pack('I'))
         rescue ::SocketError, ::Errno::ENXIO
           sock.close
           raise Rex::BindFailed.new(param.localhost, param.localport,
             reason: "Interface #{param.interface} not found"), caller
+        rescue ::SystemCallError
+          sock.close
+          raise
         end
-      else
+      elsif !Rex::Compat.is_windows
         sock.close
-        if Rex::Compat.is_windows
-          raise Rex::BindFailed.new(param.localhost, param.localport,
-            reason: 'Interface binding is not supported on Windows'), caller
-        else
-          raise Rex::BindFailed.new(param.localhost, param.localport,
-            reason: 'Interface binding is not supported on this platform'), caller
-        end
+        raise Rex::BindFailed.new(param.localhost, param.localport,
+          reason: 'Interface binding is not supported on this platform'), caller
       end
     end
 

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -214,8 +214,13 @@ class Rex::Socket::Comm::Local
         end
       else
         sock.close
-        raise Rex::BindFailed.new(param.localhost, param.localport,
-          reason: 'Interface binding is not supported on this platform'), caller
+        if Rex::Compat.is_windows
+          raise Rex::BindFailed.new(param.localhost, param.localport,
+            reason: 'Interface binding is not supported on Windows'), caller
+        else
+          raise Rex::BindFailed.new(param.localhost, param.localport,
+            reason: 'Interface binding is not supported on this platform'), caller
+        end
       end
     end
 

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -159,7 +159,8 @@ class Rex::Socket::Comm::Local
     self.instance.notify_before_socket_create(self, param)
 
     if param.interface && !param.interface.empty? && param.proxies?
-      raise Rex::BindFailed.new(param.localhost, param.localport), caller
+      raise Rex::BindFailed.new(param.localhost, param.localport,
+        reason: 'Interface option is incompatible with proxy use'), caller
     end
 
     # Create the socket
@@ -195,14 +196,26 @@ class Rex::Socket::Comm::Local
           sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_BINDTODEVICE, param.interface)
         rescue ::Errno::ENODEV, ::Errno::ENXIO
           sock.close
-          raise Rex::BindFailed.new(param.localhost, param.localport), caller
+          raise Rex::BindFailed.new(param.localhost, param.localport,
+            reason: "Interface #{param.interface} not found"), caller
         rescue ::Errno::EPERM
           sock.close
-          raise Rex::BindFailed.new(param.localhost, param.localport), caller
+          raise Rex::BindFailed.new(param.localhost, param.localport,
+            reason: "Binding to interface #{param.interface} requires elevated privileges"), caller
+        end
+      elsif Rex::Compat.is_osx && defined?(::Socket::IP_BOUND_IF)
+        begin
+          idx = ::Socket.if_nametoindex(param.interface)
+          sock.setsockopt(::Socket::IPPROTO_IP, ::Socket::IP_BOUND_IF, [idx].pack('I'))
+        rescue ::SocketError, ::Errno::ENXIO
+          sock.close
+          raise Rex::BindFailed.new(param.localhost, param.localport,
+            reason: "Interface #{param.interface} not found"), caller
         end
       else
         sock.close
-        raise Rex::BindFailed.new(param.localhost, param.localport), caller
+        raise Rex::BindFailed.new(param.localhost, param.localport,
+          reason: 'Interface binding is not supported on this platform'), caller
       end
     end
 

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -167,30 +167,30 @@ class Rex::Socket::Comm::Local
         reason: 'Interface option is incompatible with proxy use'), caller
     end
 
+    # On Windows, interface binding is handled by resolving the interface
+    # name to an IP address and overriding localhost before socket creation.
+    # No setsockopt-based interface binding is used.
     if param.interface && !param.interface.empty? && Rex::Compat.is_windows
       iface_ip = nil
-      iface_found = false
       begin
-        ::Socket.getifaddrs.each do |ifaddr|
-          next unless ifaddr.name == param.interface
-          iface_found = true
+        ifaddrs = ::Socket.getifaddrs.select { |ifaddr| ifaddr.name == param.interface }
+        iface = ifaddrs.find do |ifaddr|
           if param.v6
-            next unless ifaddr.addr&.ipv6?
+            ifaddr.addr&.ipv6?
           else
-            next unless ifaddr.addr&.ipv4?
+            ifaddr.addr&.ipv4?
           end
-          iface_ip = ifaddr.addr.ip_address
-          break
         end
+        iface_ip = iface&.addr&.ip_address
       rescue ::SystemCallError, ::SocketError => e
         raise Rex::BindFailed.new(param.localhost, param.localport,
           reason: "Failed to enumerate interfaces: #{e.message}"), caller
       end
       if iface_ip.nil?
-        reason = if iface_found
-          "Interface #{param.interface} has no #{param.v6 ? 'IPv6' : 'IPv4'} address"
-        else
+        reason = if ifaddrs.empty?
           "Interface #{param.interface} not found"
+        else
+          "Interface #{param.interface} has no #{param.v6 ? 'IPv6' : 'IPv4'} address"
         end
         raise Rex::BindFailed.new(param.localhost, param.localport,
           reason: reason), caller
@@ -242,15 +242,19 @@ class Rex::Socket::Comm::Local
           sock.close
           raise
         end
-      elsif Rex::Compat.is_macosx && defined?(::Socket::IP_BOUND_IF)
+      elsif Rex::Compat.is_macosx
         begin
-          idx = ::Socket.getifaddrs.find { |ifaddr| ifaddr.name == param.interface }&.ifindex
+          # IP_BOUND_IF may not be defined in Ruby builds on macOS,
+          # so we fallback to raw value 25 which is stable across versions.
+          ip_bound_if = defined?(::Socket::IP_BOUND_IF) ? ::Socket::IP_BOUND_IF : 25
+          iface = ::Socket.getifaddrs.find { |ifaddr| ifaddr.name == param.interface }
+          idx = iface&.ifindex
           if idx.nil?
             sock.close
             raise Rex::BindFailed.new(param.localhost, param.localport,
               reason: "Interface #{param.interface} not found"), caller
           end
-          sock.setsockopt(::Socket::IPPROTO_IP, ::Socket::IP_BOUND_IF, [idx].pack('I'))
+          sock.setsockopt(::Socket::IPPROTO_IP, ip_bound_if, [idx].pack('I'))
         rescue ::SocketError, ::Errno::ENXIO
           sock.close
           raise Rex::BindFailed.new(param.localhost, param.localport,

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -158,6 +158,10 @@ class Rex::Socket::Comm::Local
     # Notify handlers of the before socket create event.
     self.instance.notify_before_socket_create(self, param)
 
+    # Binding to a specific interface while routing through a proxy is not
+    # supported. The proxy comm handles its own socket creation and ignores
+    # the interface option entirely, so we fail fast here rather than
+    # silently binding to the wrong interface.
     if param.interface && !param.interface.empty? && param.proxies?
       raise Rex::BindFailed.new(param.localhost, param.localport,
         reason: 'Interface option is incompatible with proxy use'), caller
@@ -170,7 +174,11 @@ class Rex::Socket::Comm::Local
         ::Socket.getifaddrs.each do |ifaddr|
           next unless ifaddr.name == param.interface
           iface_found = true
-          next unless ifaddr.addr&.ipv4?
+          if param.v6
+            next unless ifaddr.addr&.ipv6?
+          else
+            next unless ifaddr.addr&.ipv4?
+          end
           iface_ip = ifaddr.addr.ip_address
           break
         end
@@ -180,13 +188,14 @@ class Rex::Socket::Comm::Local
       end
       if iface_ip.nil?
         reason = if iface_found
-          "Interface #{param.interface} has no IPv4 address"
+          "Interface #{param.interface} has no #{param.v6 ? 'IPv6' : 'IPv4'} address"
         else
           "Interface #{param.interface} not found"
         end
         raise Rex::BindFailed.new(param.localhost, param.localport,
           reason: reason), caller
       end
+      param = param.dup  # avoid mutating the caller's instance
       param.localhost = iface_ip
     end
 

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -158,6 +158,10 @@ class Rex::Socket::Comm::Local
     # Notify handlers of the before socket create event.
     self.instance.notify_before_socket_create(self, param)
 
+    if param.interface && !param.interface.empty? && param.proxies?
+      raise Rex::BindFailed.new(param.localhost, param.localport), caller
+    end
+
     # Create the socket
     sock = nil
     if param.v6
@@ -180,6 +184,23 @@ class Rex::Socket::Comm::Local
         sock.bind(Rex::Socket.to_sockaddr(param.localhost, param.localport))
 
       rescue ::Errno::EADDRNOTAVAIL,::Errno::EADDRINUSE
+        sock.close
+        raise Rex::BindFailed.new(param.localhost, param.localport), caller
+      end
+    end
+
+    if param.interface && !param.interface.empty?
+      if Rex::Compat.is_linux
+        begin
+          sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_BINDTODEVICE, param.interface)
+        rescue ::Errno::ENODEV, ::Errno::ENXIO
+          sock.close
+          raise Rex::BindFailed.new(param.localhost, param.localport), caller
+        rescue ::Errno::EPERM
+          sock.close
+          raise Rex::BindFailed.new(param.localhost, param.localport), caller
+        end
+      else
         sock.close
         raise Rex::BindFailed.new(param.localhost, param.localport), caller
       end

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -81,6 +81,9 @@ class Rex::Socket::Parameters
   #   retried.
   # @option hash [Fixnum] 'Timeout' The number of seconds before a connection
   #   should time out
+  # @option hash [String] 'Interface' The network interface name to bind the socket to
+  #   (e.g. 'eth0'). Only honoured by the local Comm; raises Rex::BindFailed if combined
+  #   with a proxy.
   def initialize(hash = {})
     if (hash['PeerHost'])
       self.peerhost = hash['PeerHost']
@@ -202,6 +205,9 @@ class Rex::Socket::Parameters
     if hash['Timeout']
       self.timeout = hash['Timeout'].to_i
     end
+
+    self.interface = hash['Interface'].to_s.strip if hash['Interface']
+
 
     # Whether to force IPv6 addressing
     if hash['IPv6'].nil?
@@ -485,6 +491,10 @@ class Rex::Socket::Parameters
   # List of proxies to use
   # @return [Array]
   attr_accessor :proxies
+
+  # The network interface name to bind the socket to (e.g. 'eth0'). nil means no binding.
+  # @return [String, nil]
+  attr_accessor :interface
 
   def proxies?
     proxies && !proxies.empty?

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -206,8 +206,7 @@ class Rex::Socket::Parameters
       self.timeout = hash['Timeout'].to_i
     end
 
-    self.interface = hash['Interface'].to_s.strip if hash['Interface']
-
+    self.interface = hash['Interface'].to_s.strip if hash['Interface'] && !hash['Interface'].strip.empty?
 
     # Whether to force IPv6 addressing
     if hash['IPv6'].nil?

--- a/spec/rex/socket/comm/local_spec.rb
+++ b/spec/rex/socket/comm/local_spec.rb
@@ -107,4 +107,60 @@ RSpec.describe Rex::Socket::Comm::Local do
       end
     end
   end
+
+  describe 'Interface option' do
+    context 'when Interface is set and a proxy is also configured' do
+      it 'raises Rex::BindFailed before creating a socket' do
+        params = Rex::Socket::Parameters.new(
+          'Proto'     => 'udp',
+          'Interface' => 'lo',
+          'Proxies'   => 'socks5:127.0.0.1:1080'
+        )
+        expect { described_class.create(params) }.to raise_error(Rex::BindFailed)
+      end
+    end
+
+    context 'when Interface is set to a name that cannot exist' do
+      it 'raises Rex::BindFailed' do
+        skip 'Linux only' unless Rex::Compat.is_linux
+        skip 'requires root (SO_BINDTODEVICE)' unless Process.uid == 0
+        params = Rex::Socket::Parameters.new(
+          'Proto'     => 'udp',
+          'LocalHost' => '127.0.0.1',
+          'LocalPort' => 0,
+          'Interface' => 'xX_no_such_iface_Xx'
+        )
+        expect { described_class.create(params) }.to raise_error(Rex::BindFailed)
+      end
+    end
+
+    context 'when Interface is set to loopback on Linux' do
+      it 'creates the socket successfully' do
+        skip 'Linux only' unless Rex::Compat.is_linux
+        skip 'requires root (SO_BINDTODEVICE)' unless Process.uid == 0
+        params = Rex::Socket::Parameters.new(
+          'Proto'     => 'udp',
+          'LocalHost' => '127.0.0.1',
+          'LocalPort' => 0,
+          'Interface' => 'lo'
+        )
+        sock = described_class.create(params)
+        expect(sock).not_to be_nil
+        sock.close
+      end
+    end
+
+    context 'when running on a non-Linux platform' do
+      it 'raises Rex::BindFailed' do
+        skip 'non-Linux only' if Rex::Compat.is_linux
+        params = Rex::Socket::Parameters.new(
+          'Proto'     => 'udp',
+          'LocalHost' => '127.0.0.1',
+          'LocalPort' => 0,
+          'Interface' => 'lo'
+        )
+        expect { described_class.create(params) }.to raise_error(Rex::BindFailed)
+      end
+    end
+  end
 end

--- a/spec/rex/socket/parameters_spec.rb
+++ b/spec/rex/socket/parameters_spec.rb
@@ -125,4 +125,27 @@ RSpec.describe Rex::Socket::Parameters do
     end
   end
 
+  describe '#interface' do
+    it 'is nil by default' do
+      params = described_class.new({})
+      expect(params.interface).to be_nil
+    end
+
+    it 'is set from the Interface hash key' do
+      params = described_class.new('Interface' => 'eth0')
+      expect(params.interface).to eq('eth0')
+    end
+
+    it 'strips leading and trailing whitespace' do
+      params = described_class.new('Interface' => '  lo  ')
+      expect(params.interface).to eq('lo')
+    end
+
+    it 'is nil when the key is absent, not an empty string' do
+      params = described_class.new({})
+      expect(params.interface).to be_nil
+      expect(params.interface).not_to eq('')
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary

Adds an `Interface` option to `Rex::Socket::Parameters` so callers can
bind a socket to a specific network interface by name:
```ruby
Rex::Socket::Udp.create('Interface' => 'eth0', ...)
Rex::Socket::Tcp.create('Interface' => 'eth0', ...)
Rex::Socket::TcpServer.create('Interface' => 'eth0', ...)
```

This is needed for broadcast-capable sockets (e.g. the DHCP server module)
where binding by IP address alone is insufficient — the socket must be bound
to a specific interface to send and receive broadcast frames correctly.

## Changes

- `lib/rex/socket/parameters.rb` — adds `interface` attribute, parsed from
  the `'Interface'` hash key, whitespace-stripped, `nil` by default
- `lib/rex/socket/comm/local.rb` — two additions inside `create_by_type`:
  1. Guard: raises `Rex::BindFailed` immediately if `Interface` is combined
     with a proxy (incompatible by design)
  2. Calls `setsockopt(SOL_SOCKET, SO_BINDTODEVICE, interface)` after the
     normal bind block, before `SO_BROADCAST` — Linux only. Non-Linux
     platforms raise `Rex::BindFailed` (macOS `IP_BOUND_IF` is not available
     in the current Ruby stdlib and can be added as a follow-up)
- `spec/rex/socket/parameters_spec.rb` — new `#interface` describe block
- `spec/rex/socket/comm/local_spec.rb` — new `Interface option` describe
  block covering proxy guard, invalid interface name, loopback success
  (root-guarded), and non-Linux platform

## Testing
```
bundle exec rspec spec/ --format documentation
# 178 examples, 0 failures, 3 pending (root-only / platform-specific skips)
```

## Notes

- All RuboCop offenses in the diff are pre-existing in these files
- macOS support can be added in a follow-up PR once `IP_BOUND_IF`
  availability across Ruby versions is confirmed
- Closes #21114
- Part of rapid7/metasploit-framework#21113
```