### PR TITLE
Defer loading dnsruby

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -4,7 +4,7 @@ require 'socket'
 require 'thread'
 require 'resolv'
 require 'rex/exceptions'
-require 'dnsruby'
+autoload :Dnsruby, 'dnsruby'
 
 module Rex
 


### PR DESCRIPTION
Defer loading dnsruby until it's needed, to decrease load time