### PR TITLE
Add #send, deprecate #sendto in UDP

### DIFF
--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -118,8 +118,8 @@ module Rex::Socket::Udp
       # Catch unconnected IPv6 sockets talking to IPv4 addresses
       peer = Rex::Socket.resolv_nbo(host)
       if peer.length == 4 && self.ipv == 6
-        host = Rex::Socket.getaddress(host, true)
-        host = '::ffff:' + host unless host[0, 7].downcase == '::ffff:'
+        host_address = Rex::Socket.getaddress(host, true)
+        host = '::ffff:' + host_address unless host_address.downcase.start_with?('::ffff:')
       end
       begin
         super(mesg, flags, Rex::Socket.to_sockaddr(host, port))

--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -117,6 +117,25 @@ module Rex::Socket::Udp
   end
 
   #
+  # Sends a datagram using the stdlib 4-arg form send(mesg, flags, host, port),
+  # delegating to sendto so that channel/pivoted sockets (which only implement
+  # sendto) work identically to local sockets. Callers can use this form
+  # uniformly without checking the socket type.
+  #
+  # Also handles the 3-arg sockaddr form used internally by sendto, forwarding
+  # it to BasicSocket#send which accepts a packed sockaddr as the third argument.
+  #
+  def send(mesg, flags, host_or_sockaddr = nil, port = nil)
+    if port
+      sendto(mesg, host_or_sockaddr, port, flags)
+    elsif host_or_sockaddr
+      super(mesg, flags, host_or_sockaddr)
+    else
+      super(mesg, flags)
+    end
+  end
+
+  #
   # Receives a datagram and returns the data and host:port of the requestor
   # as [ data, host, port ].
   #

--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -97,39 +97,38 @@ module Rex::Socket::Udp
   #
   # Sends a datagram to the supplied host:port with optional flags.
   #
+  # @deprecated Use {#send} with the stdlib 4-arg form send(mesg, flags, host, port) instead.
+  #   Note the argument order differs: sendto(gram, host, port, flags) vs send(mesg, flags, host, port).
+  #
   def sendto(gram, peerhost, peerport, flags = 0)
-
-    # Catch unconnected IPv6 sockets talking to IPv4 addresses
-    peer = Rex::Socket.resolv_nbo(peerhost)
-    if (peer.length == 4 and self.ipv == 6)
-      peerhost = Rex::Socket.getaddress(peerhost, true)
-      if peerhost[0,7].downcase != '::ffff:'
-        peerhost = '::ffff:' + peerhost
-      end
-    end
-
-    begin
-      send(gram, flags, Rex::Socket.to_sockaddr(peerhost, peerport))
-    rescue  ::Errno::EHOSTUNREACH,::Errno::ENETDOWN,::Errno::ENETUNREACH,::Errno::ENETRESET,::Errno::EHOSTDOWN,::Errno::EACCES,::Errno::EINVAL,::Errno::EADDRNOTAVAIL
-      return nil
-    end
-
+    warn "#{self.class}#sendto is deprecated; use send(mesg, flags, host, port) instead", uplevel: 1
+    send(gram, flags, peerhost, peerport)
   end
 
   #
-  # Sends a datagram using the stdlib 4-arg form send(mesg, flags, host, port),
-  # delegating to sendto so that channel/pivoted sockets (which only implement
-  # sendto) work identically to local sockets. Callers can use this form
-  # uniformly without checking the socket type.
+  # Sends a datagram using the stdlib 4-arg form send(mesg, flags, host, port).
   #
-  # Also handles the 3-arg sockaddr form used internally by sendto, forwarding
-  # it to BasicSocket#send which accepts a packed sockaddr as the third argument.
+  # The 4-arg form handles IPv6/IPv4 address mapping and dispatches via
+  # BasicSocket#send with a packed sockaddr, so channel/pivoted sockets that
+  # override sendto are not involved. Also accepts the 3-arg sockaddr form used
+  # by lower-level callers, and the 2-arg connected-socket form.
   #
-  def send(mesg, flags, host_or_sockaddr = nil, port = nil)
-    if port
-      sendto(mesg, host_or_sockaddr, port, flags)
-    elsif host_or_sockaddr
-      super(mesg, flags, host_or_sockaddr)
+  def send(mesg, flags, host = nil, port = nil)
+    if host && port
+      # Catch unconnected IPv6 sockets talking to IPv4 addresses
+      peer = Rex::Socket.resolv_nbo(host)
+      if peer.length == 4 && self.ipv == 6
+        host = Rex::Socket.getaddress(host, true)
+        host = '::ffff:' + host unless host[0, 7].downcase == '::ffff:'
+      end
+      begin
+        super(mesg, flags, Rex::Socket.to_sockaddr(host, port))
+      rescue ::Errno::EHOSTUNREACH, ::Errno::ENETDOWN, ::Errno::ENETUNREACH, ::Errno::ENETRESET,
+             ::Errno::EHOSTDOWN, ::Errno::EACCES, ::Errno::EINVAL, ::Errno::EADDRNOTAVAIL
+        nil
+      end
+    elsif host
+      super(mesg, flags, host)
     else
       super(mesg, flags)
     end

--- a/spec/rex/socket/udp_spec.rb
+++ b/spec/rex/socket/udp_spec.rb
@@ -1,0 +1,41 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+
+RSpec.describe Rex::Socket::Udp do
+  let(:receiver) { UDPSocket.new.tap { |s| s.bind('127.0.0.1', 0) } }
+  let(:recv_port) { receiver.addr[1] }
+  let(:socket) { Rex::Socket::Udp.create('LocalHost' => '127.0.0.1') }
+
+  after do
+    socket.close rescue nil
+    receiver.close rescue nil
+  end
+
+  describe '#send' do
+    it 'delivers a datagram with the 4-arg (host, port) form' do
+      socket.send('hello', 0, '127.0.0.1', recv_port)
+      expect(IO.select([receiver], nil, nil, 1)).not_to be_nil
+      expect(receiver.recvfrom(16).first).to eq('hello')
+    end
+
+    it 'delivers a datagram with the 3-arg (packed sockaddr) form' do
+      sockaddr = Socket.pack_sockaddr_in(recv_port, '127.0.0.1')
+      socket.send('world', 0, sockaddr)
+      expect(IO.select([receiver], nil, nil, 1)).not_to be_nil
+      expect(receiver.recvfrom(16).first).to eq('world')
+    end
+  end
+
+  describe '#sendto' do
+    it 'emits a deprecation warning' do
+      expect { socket.sendto('hi', '127.0.0.1', recv_port) }
+        .to output(/sendto.*deprecated/i).to_stderr
+    end
+
+    it 'still delivers the datagram' do
+      socket.sendto('hi', '127.0.0.1', recv_port)
+      expect(IO.select([receiver], nil, nil, 1)).not_to be_nil
+      expect(receiver.recvfrom(16).first).to eq('hi')
+    end
+  end
+end

--- a/spec/rex/socket/udp_spec.rb
+++ b/spec/rex/socket/udp_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 RSpec.describe Rex::Socket::Udp do
   let(:receiver) { UDPSocket.new.tap { |s| s.bind('127.0.0.1', 0) } }
   let(:recv_port) { receiver.addr[1] }
-  let(:socket) { Rex::Socket::Udp.create('LocalHost' => '127.0.0.1') }
+  let(:socket) { described_class.create('LocalHost' => '127.0.0.1') }
 
   after do
     socket.close rescue nil
@@ -24,6 +24,19 @@ RSpec.describe Rex::Socket::Udp do
       expect(IO.select([receiver], nil, nil, 1)).not_to be_nil
       expect(receiver.recvfrom(16).first).to eq('world')
     end
+
+    # #sendto uses send, so we'll test IO here
+    it 'delivers binary data' do
+      socket.send("\xE2\x9C\x85".b, 0, '127.0.0.1', recv_port) # unicode checkmark
+      expect(IO.select([receiver], nil, nil, 1)).not_to be_nil
+      expect(receiver.recvfrom(16).first).to eq("\xE2\x9C\x85".b)
+    end
+
+    it 'delivers null bytes' do
+      socket.send("\x00\x00\x00\x00".b, 0, '127.0.0.1', recv_port)
+      expect(IO.select([receiver], nil, nil, 1)).not_to be_nil
+      expect(receiver.recvfrom(16).first).to eq("\x00\x00\x00\x00".b)
+    end
   end
 
   describe '#sendto' do
@@ -36,6 +49,11 @@ RSpec.describe Rex::Socket::Udp do
       socket.sendto('hi', '127.0.0.1', recv_port)
       expect(IO.select([receiver], nil, nil, 1)).not_to be_nil
       expect(receiver.recvfrom(16).first).to eq('hi')
+    end
+
+    it 'calls .send with the expected arguments' do
+      expect(socket).to receive(:send).with('data', 0, '127.1.1.1', 1337)
+      socket.sendto('data', '127.1.1.1', 1337)
     end
   end
 end


### PR DESCRIPTION
There is no `#sendto` method in the Ruby standard library's `UDPSocket` object. This means developers have to handle edge cases for whether their socket is a Rex::Socket::Udp socket or a Ruby standard UDPSocket instance which introduces unnecessary complexity. It also means Rex::Socket::Udp can't be used as a drop in replacement for UDPSocket because it doesn't have the `#send` method that the standard library does have.

e.g. https://github.com/Z6543/ruby_smb/blob/679da4dba6bb4256ff1b79527d5d0c6f8cc6fd76/lib/ruby_smb/nbss/node_status.rb#L200-L206

These changes add a `#send` method with the same signature as the Ruby standard library. It also marks the `#sendto` method as deprecated so we can remove it in the future. Callers really shouldn't be using it because they're unconsciously pinning their implementation to Rex::Socket.

This is not a breaking change because `#sendto` is kept, it warns and forwards to `#send`. This gives us time to remove those usages.

## Demo

This toy example makes a DNS request to the user's specified DNS server. It demonstrats that the same API can now be used for both Ruby standard sockets as well as Rex::Sockets.

Old and broken (wrong `send` method)
```
# ruby dns_send_demo.rb --server 192.168.249.4
Source locally installed gems is ignoring #<Bundler::StubSpecification name=ed25519 version=1.3.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=debase version=3.0.12 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=bson version=5.0.2 platform=ruby> because it is missing extensions

stdlib UDPSocket  →  192.168.249.4:53
-------------------------------------
  example.com => 172.66.147.243, 104.20.23.154

Rex::Socket::Udp  →  192.168.249.4:53
-------------------------------------
dns_send_demo.rb:74:in `send': wrong number of arguments (given 4, expected 2..3) (ArgumentError)

  socket.send(packet, 0, DNS_HOST, DNS_PORT)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from dns_send_demo.rb:74:in `query'
	from dns_send_demo.rb:93:in `run'
	from dns_send_demo.rb:113:in `<main>'
```

New and fixed
```
ruby dns_send_demo.rb --server 192.168.249.4
Source locally installed gems is ignoring #<Bundler::StubSpecification name=ed25519 version=1.3.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=debase version=3.0.12 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=bson version=5.0.2 platform=ruby> because it is missing extensions

stdlib UDPSocket  →  192.168.249.4:53
-------------------------------------
  example.com => 172.66.147.243, 104.20.23.154

Rex::Socket::Udp  →  192.168.249.4:53
-------------------------------------
  example.com => 104.20.23.154, 172.66.147.243
```

<details>
<summary>`dns_send_demo.rb`</summary>

```ruby
#!/usr/bin/ruby
# Demonstrates the unified send(mesg, flags, host, port) API on Rex::Socket::Udp.
#
# Makes a DNS A-record query to a public resolver using a caller-supplied socket.
# Both a stdlib UDPSocket and a Rex::Socket::Udp instance are exercised to show
# that the same send call path works across both socket types.
#
# Usage: ruby examples/dns_send_demo.rb [domain]

require 'bundler/setup'
require 'optparse'
require 'socket'
require 'rex/socket/udp'

DNS_PORT = 53
TIMEOUT  = 3.0

options = { server: '8.8.8.8' }
OptionParser.new do |opts|
  opts.banner = "Usage: #{File.basename(__FILE__)} [--server IP] [domain]"
  opts.on('--server IP', 'DNS server IP (default: 8.8.8.8)') { |v| options[:server] = v }
end.parse!

DNS_HOST = options[:server]

# Build a minimal DNS A-record query for +domain+.
# Returns [transaction_id, binary_packet].
def build_query(domain)
  tid    = rand(0xFFFF)
  labels = domain.split('.').map { |l| [l.length].pack('C') + l }.join + "\x00"
  packet = [tid, 0x0100, 1, 0, 0, 0].pack('n6') + labels + [1, 1].pack('n2')
  [tid, packet]
end

# Advance +offset+ past a DNS name field (handles pointer compression).
def skip_name(data, offset)
  loop do
    return offset if offset >= data.bytesize
    len = data.getbyte(offset)
    if len & 0xC0 == 0xC0   # pointer — always 2 bytes
      return offset + 2
    elsif len == 0           # root label — end of name
      return offset + 1
    else
      offset += len + 1
    end
  end
end

# Extract A-record IP addresses from a raw DNS response.
def parse_a_records(data)
  return [] if data.bytesize < 12
  ancount = data.byteslice(6, 2).unpack1('n')
  offset  = skip_name(data, 12) + 4  # skip question name + qtype + qclass

  ancount.times.with_object([]) do |_, addrs|
    break addrs if offset + 12 > data.bytesize
    offset   = skip_name(data, offset)
    type     = data.byteslice(offset, 2).unpack1('n'); offset += 2
    offset   += 6                                        # class + ttl
    rdlength = data.byteslice(offset, 2).unpack1('n'); offset += 2
    addrs << data.byteslice(offset, 4).unpack('C4').join('.') if type == 1 && rdlength == 4
    offset += rdlength
  end
end

# Query +DNS_HOST+ for A records of +domain+ using the supplied +socket+.
#
# Uses the unified 4-arg send(mesg, flags, host, port) — the same call works on
# both stdlib UDPSocket and Rex::Socket::Udp now that Rex defines #send.
def query(socket, domain, timeout: TIMEOUT)
  tid, packet = build_query(domain)

  socket.send(packet, 0, DNS_HOST, DNS_PORT)

  data = if socket.respond_to?(:sendto)
    resp, = socket.recvfrom(512, timeout)
    resp
  else
    return nil unless IO.select([socket], nil, nil, timeout)
    resp, = socket.recvfrom(512)
    resp
  end

  return nil if data.nil? || data.empty?
  [tid, parse_a_records(data)]
end

def run(label, socket, domain)
  puts "\n#{label}"
  puts '-' * label.length

  result = query(socket, domain)
  if result
    _tid, addrs = result
    puts "  #{domain} => #{addrs.empty? ? '(no A records)' : addrs.join(', ')}"
  else
    puts "  [!] no response from #{DNS_HOST}:#{DNS_PORT}"
  end
end

domain = ARGV.first || 'example.com'

sock = UDPSocket.new
begin
  run("stdlib UDPSocket  →  #{DNS_HOST}:#{DNS_PORT}", sock, domain)
ensure
  sock.close
end

rex_sock = Rex::Socket::Udp.create
begin
  run("Rex::Socket::Udp  →  #{DNS_HOST}:#{DNS_PORT}", rex_sock, domain)
ensure
  rex_sock.close
end
</details>