### PR TITLE
Fix #recvfrom to match stdlib

### DIFF
--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -135,26 +135,54 @@ module Rex::Socket::Udp
   end
 
   #
-  # Receives a datagram and returns the data and sender address information
-  # as [ data, [address_family, port, host, host] ], matching the format of
-  # stdlib UDPSocket#recvfrom (host appears in both the hostname and numeric
-  # address positions; no reverse-DNS lookup is performed).
+  # Receives a datagram and returns the data and sender address information as
+  # [ data, [address_family, port, host, host] ], matching stdlib
+  # UDPSocket#recvfrom. Like the stdlib method, this blocks until a datagram is
+  # available and has no timeout of its own (see #timed_recvfrom for a variant
+  # that does). The host appears in both the hostname and numeric address
+  # positions; no reverse-DNS lookup is performed.
   #
   # @param maxlen [Integer] maximum number of bytes to receive
   # @param flags [Integer] flags passed to the underlying recvfrom(2) call (default: 0)
+  # @return [Array(String, Array)] the datagram and the sender address information
   #
   def recvfrom(maxlen, flags = 0)
-    rv = ::IO.select([ fd ], nil, nil, def_read_timeout)
-
-    raise Errno::EAGAIN, "Resource temporarily unavailable" if rv.nil?
-
+    # Block until the socket is readable to mirror the stdlib's blocking
+    # UDPSocket#recvfrom; a nil timeout waits indefinitely.
+    ::IO.select([ fd ], nil, nil, nil)
     data, saddr = recvfrom_nonblock(maxlen, flags)
-    af, host, port = Rex::Socket.from_sockaddr(saddr)
-    af_name = Socket.constants.grep(/^AF_/).find { |c| Socket.const_get(c) == af }.to_s
-    [data, [af_name, port, host, host]]
-  rescue ::Timeout::Error
-    raise Errno::EAGAIN, "Resource temporarily unavailable"
+    [ data, sender_addr_info(saddr) ]
   end
+
+  #
+  # Receives a datagram like #recvfrom but waits at most +timeout+ seconds for
+  # one to arrive, returning nil if the timeout elapses first. The return value
+  # otherwise matches #recvfrom: [ data, [address_family, port, host, host] ].
+  #
+  # @param maxlen [Integer] maximum number of bytes to receive
+  # @param timeout [Numeric] seconds to wait for a datagram before giving up
+  # @return [Array(String, Array), nil] the datagram and sender address
+  #   information, or nil if no datagram arrived within +timeout+ seconds
+  #
+  def timed_recvfrom(maxlen = 65535, timeout = def_read_timeout)
+    return nil unless ::IO.select([ fd ], nil, nil, timeout)
+
+    data, saddr = recvfrom_nonblock(maxlen)
+    [ data, sender_addr_info(saddr) ]
+  rescue ::Timeout::Error
+    nil
+  end
+
+  #
+  # Converts a packed sockaddr into the stdlib UDPSocket#recvfrom-style sender
+  # address tuple [ address_family, port, host, host ].
+  #
+  def sender_addr_info(saddr)
+    af, host, port = Rex::Socket.from_sockaddr(saddr)
+    af_name = ::Socket.constants.grep(/^AF_/).find { |c| ::Socket.const_get(c) == af }.to_s
+    [ af_name, port, host, host ]
+  end
+  private :sender_addr_info
 
   #
   # Calls recvfrom and only returns the data

--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -135,37 +135,37 @@ module Rex::Socket::Udp
   end
 
   #
-  # Receives a datagram and returns the data and host:port of the requestor
-  # as [ data, host, port ].
+  # Receives a datagram and returns the data and sender address information
+  # as [ data, [address_family, port, host, host] ], matching the format of
+  # stdlib UDPSocket#recvfrom (host appears in both the hostname and numeric
+  # address positions; no reverse-DNS lookup is performed).
   #
-  def recvfrom(length = 65535, timeout=def_read_timeout)
+  # @param maxlen [Integer] maximum number of bytes to receive
+  # @param timeout [Numeric] seconds to wait before raising Errno::EAGAIN
+  #   (default: def_read_timeout = 10). NOTE: this parameter was previously
+  #   named +flags+ and defaulted to 0; callers that passed flags=0 explicitly
+  #   will now receive a 0-second (poll) receive instead of a 10-second wait.
+  #
+  def recvfrom(maxlen, timeout = def_read_timeout)
+    rv = ::IO.select([ fd ], nil, nil, timeout)
 
-    begin
-      if ((rv = ::IO.select([ fd ], nil, nil, timeout)) and
-          (rv[0]) and (rv[0][0] == fd)
-         )
-          data, saddr    = recvfrom_nonblock(length)
-          af, host, port = Rex::Socket.from_sockaddr(saddr)
+    raise Errno::EAGAIN, "Resource temporarily unavailable" if rv.nil?
 
-          return [ data, host, port ]
-      else
-        return [ '', nil, nil ]
-      end
-    rescue ::Timeout::Error
-      return [ '', nil, nil ]
-    rescue ::Interrupt
-      raise $!
-    rescue ::Exception
-      return [ '', nil, nil ]
-    end
+    data, saddr = recvfrom_nonblock(maxlen)
+    af, host, port = Rex::Socket.from_sockaddr(saddr)
+    af_name = Socket.constants.grep(/^AF_/).find { |c| Socket.const_get(c) == af }.to_s
+    [data, [af_name, port, host, host]]
+  rescue ::Timeout::Error
+    raise Errno::EAGAIN, "Resource temporarily unavailable"
+  rescue ::Interrupt
+    raise
   end
 
   #
   # Calls recvfrom and only returns the data
   #
   def get(timeout=nil)
-    data, saddr, sport = recvfrom(65535, timeout)
-    return data
+    timed_read(65535, timeout)
   end
 
   #

--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -185,7 +185,7 @@ module Rex::Socket::Udp
   private :sender_addr_info
 
   #
-  # Calls recvfrom and only returns the data
+  # Calls #timed_read and returns the data
   #
   def get(timeout=nil)
     timed_read(65535, timeout)

--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -169,7 +169,7 @@ module Rex::Socket::Udp
 
     data, saddr = recvfrom_nonblock(maxlen)
     [ data, sender_addr_info(saddr) ]
-  rescue ::Timeout::Error
+  rescue ::Timeout::Error, ::Errno::ECONNREFUSED
     nil
   end
 

--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -141,24 +141,19 @@ module Rex::Socket::Udp
   # address positions; no reverse-DNS lookup is performed).
   #
   # @param maxlen [Integer] maximum number of bytes to receive
-  # @param timeout [Numeric] seconds to wait before raising Errno::EAGAIN
-  #   (default: def_read_timeout = 10). NOTE: this parameter was previously
-  #   named +flags+ and defaulted to 0; callers that passed flags=0 explicitly
-  #   will now receive a 0-second (poll) receive instead of a 10-second wait.
+  # @param flags [Integer] flags passed to the underlying recvfrom(2) call (default: 0)
   #
-  def recvfrom(maxlen, timeout = def_read_timeout)
-    rv = ::IO.select([ fd ], nil, nil, timeout)
+  def recvfrom(maxlen, flags = 0)
+    rv = ::IO.select([ fd ], nil, nil, def_read_timeout)
 
     raise Errno::EAGAIN, "Resource temporarily unavailable" if rv.nil?
 
-    data, saddr = recvfrom_nonblock(maxlen)
+    data, saddr = recvfrom_nonblock(maxlen, flags)
     af, host, port = Rex::Socket.from_sockaddr(saddr)
     af_name = Socket.constants.grep(/^AF_/).find { |c| Socket.const_get(c) == af }.to_s
     [data, [af_name, port, host, host]]
   rescue ::Timeout::Error
     raise Errno::EAGAIN, "Resource temporarily unavailable"
-  rescue ::Interrupt
-    raise
   end
 
   #

--- a/spec/rex/socket/udp_spec.rb
+++ b/spec/rex/socket/udp_spec.rb
@@ -1,14 +1,40 @@
-# -*- coding: binary -*-
+# -*- coding:binary -*-
 require 'spec_helper'
 
 RSpec.describe Rex::Socket::Udp do
-  let(:receiver) { UDPSocket.new.tap { |s| s.bind('127.0.0.1', 0) } }
+  let(:loopback) { '127.0.0.1' }
+  let(:receiver) { UDPSocket.new.tap { |s| s.bind(loopback, 0) } }
   let(:recv_port) { receiver.addr[1] }
-  let(:socket) { described_class.create('LocalHost' => '127.0.0.1') }
+  let(:socket) { described_class.create('LocalHost' => loopback) }
 
-  after do
-    socket.close rescue nil
-    receiver.close rescue nil
+  def make_server
+    Rex::Socket::Udp.create('LocalHost' => loopback, 'LocalPort' => 0)
+  end
+
+  def make_client(port)
+    Rex::Socket::Udp.create('PeerHost' => loopback, 'PeerPort' => port)
+  end
+
+  describe '#recvfrom' do
+    it 'returns the data and a stdlib-style sender address tuple' do
+      server = make_server
+      client = make_client(server.local_address.ip_port)
+      client.write('hello')
+
+      data, addr = server.recvfrom(65535)
+      expect(data).to eq('hello')
+      expect(addr).to be_an(Array)
+      expect(addr.length).to eq(4)
+
+      af_name, port, host, numeric = addr
+      expect(af_name).to eq('AF_INET')
+      expect(port).to be_a(Integer)
+      expect(host).to eq(loopback)
+      expect(numeric).to eq(loopback)
+    ensure
+      client&.close
+      server&.close
+    end
   end
 
   describe '#send' do
@@ -54,6 +80,31 @@ RSpec.describe Rex::Socket::Udp do
     it 'calls .send with the expected arguments' do
       expect(socket).to receive(:send).with('data', 0, '127.1.1.1', 1337)
       socket.sendto('data', '127.1.1.1', 1337)
+    end
+  end
+
+  describe '#timed_recvfrom' do
+    it 'returns the datagram and sender address when one arrives in time' do
+      server = make_server
+      client = make_client(server.local_address.ip_port)
+      client.write('ping')
+
+      result = server.timed_recvfrom(65535, 5)
+      expect(result).to_not be_nil
+
+      data, addr = result
+      expect(data).to eq('ping')
+      expect(addr).to eq(['AF_INET', addr[1], loopback, loopback])
+    ensure
+      client&.close
+      server&.close
+    end
+
+    it 'returns nil when no datagram arrives before the timeout' do
+      server = make_server
+      expect(server.timed_recvfrom(65535, 0.1)).to be_nil
+    ensure
+      server&.close
     end
   end
 end

--- a/spec/rex/socket/udp_spec.rb
+++ b/spec/rex/socket/udp_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Rex::Socket::Udp do
   let(:socket) { described_class.create('LocalHost' => loopback) }
 
   def make_server
-    Rex::Socket::Udp.create('LocalHost' => loopback, 'LocalPort' => 0)
+    described_class.create('LocalHost' => loopback, 'LocalPort' => 0)
   end
 
   def make_client(port)
-    Rex::Socket::Udp.create('PeerHost' => loopback, 'PeerPort' => port)
+    described_class.create('PeerHost' => loopback, 'PeerPort' => port)
   end
 
   describe '#recvfrom' do


### PR DESCRIPTION
This is related to #82 but unlike #82, this is a breaking change. It updates the `#recvfrom` signature to match that of the standard library. This was raised first here: https://github.com/rapid7/metasploit-framework/pull/20689#issuecomment-3534578380 and was highlighted by the condition required here: https://github.com/Z6543/ruby_smb/blob/679da4dba6bb4256ff1b79527d5d0c6f8cc6fd76/lib/ruby_smb/nbss/node_status.rb#L215-L224