### PR TITLE
Fix the address resolution for hostnames

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -256,7 +256,13 @@ class Rex::Socket::Comm::Local
           ip   = param.proxies.first.host
           port = param.proxies.first.port
         else
-          ip   = Rex::Socket.getaddress(param.peerhost)
+          if Rex::Socket.is_ip_addr?(param.peerhost)
+            ip = param.peerhost
+          elsif param.v6
+            ip = Rex::Socket.getaddresses(param.peerhost, true).select { |address| Rex::Socket.is_ipv6?(address) }.sample
+          else
+            ip = Rex::Socket.getaddresses(param.peerhost, false).select { |address| Rex::Socket.is_ipv4?(address) }.sample
+          end
           port = param.peerport
         end
 

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -177,7 +177,15 @@ class Rex::Socket::Comm::Local
           sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, true)
         end
 
-        sock.bind(Rex::Socket.to_sockaddr(param.localhost, param.localport))
+        if Rex::Socket.is_ip_addr?(param.localhost)
+          ip = param.localhost
+        elsif param.v6
+          ip = Rex::Socket.getaddresses(param.localhost, true).select { |address| Rex::Socket.is_ipv6?(address) }.sample
+        else
+          ip = Rex::Socket.getaddresses(param.localhost, false).select { |address| Rex::Socket.is_ipv4?(address) }.sample
+        end
+
+        sock.bind(Rex::Socket.to_sockaddr(ip, param.localport))
 
       rescue ::Errno::EADDRNOTAVAIL,::Errno::EADDRINUSE
         sock.close


### PR DESCRIPTION
Rex::Socket.getaddress can return either IPv4 or IPv6 addresses so when it's a hostname, use the socket type hint (#v6) to resolve the correct family of address.

This fixes an issue when the hostname resolves to both IPv4 and IPv6 addresses. In that case we should select the type of address based on the socket type we have lest, we get an error stating the it's incompatible.

Related to: https://github.com/rapid7/metasploit-framework/pull/21512
Fixes: https://github.com/rapid7/metasploit-framework/issues/21513

# Demo
In this case `localhost` maps to both 127.0.0.1 and ::1 via the /etc/hosts file. A service is listening only on 0.0.0.0:80, not on an IPv6 socket. The bug surfaces because we resolve localhost to ::1 and try to connect to it with the IPv4 socket.

## Old and broken:
```
[2] pry(main)> require 'rex/socket'
=> true
[3] pry(main)> Rex::Socket::Tcp.create('PeerHost' => 'localhost', 'PeerPort' => 80)
Errno::EAFNOSUPPORT: Address family not supported by protocol - connect(2) for [::1]:80 (Errno::EAFNOSUPPORT)
from /home/smcintyre/Projects/rex-socket/lib/rex/socket/comm/local.rb:267:in `connect'
[4] pry(main)> 
```

## New and fixed:
```
[2] pry(main)> require 'rex/socket'
=> true
[3] pry(main)> Rex::Socket::Tcp.create('PeerHost' => 'localhost', 'PeerPort' => 80)
=> #<Socket:fd 7>
[4] pry(main)> 
```