### PR TITLE
Catch ECONNRESET too for Windows

### DIFF
--- a/lib/rex/socket/udp.rb
+++ b/lib/rex/socket/udp.rb
@@ -169,7 +169,7 @@ module Rex::Socket::Udp
 
     data, saddr = recvfrom_nonblock(maxlen)
     [ data, sender_addr_info(saddr) ]
-  rescue ::Timeout::Error, ::Errno::ECONNREFUSED
+  rescue ::Timeout::Error, ::Errno::ECONNREFUSED, ::Errno::ECONNRESET
     nil
   end
 
@@ -203,4 +203,3 @@ module Rex::Socket::Udp
   end
 
 end
-

--- a/spec/rex/socket/udp_spec.rb
+++ b/spec/rex/socket/udp_spec.rb
@@ -106,5 +106,17 @@ RSpec.describe Rex::Socket::Udp do
     ensure
       server&.close
     end
+
+    [::Errno::ECONNREFUSED, ::Errno::ECONNRESET].each do |error_class|
+      it "returns nil when recvfrom_nonblock raises #{error_class}" do
+        server = make_server
+        allow(::IO).to receive(:select).with([server], nil, nil, 0.1).and_return([[server], [], []])
+        allow(server).to receive(:recvfrom_nonblock).and_raise(error_class)
+
+        expect(server.timed_recvfrom(65535, 0.1)).to be_nil
+      ensure
+        server&.close
+      end
+    end
   end
 end


### PR DESCRIPTION
Catch ECONNRESET which is what Windows raises. This makes sure that `#timed_recvfrom` behaves on Windows as it does on Linux when the peer is unreacable and it's a "connected" UDP socket.

* Fixes #85
* Related to rapid7/metasploit-framework#21618