### PR TITLE
Fix broken ssl server support on windows

### DIFF
--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -72,11 +72,11 @@ module Rex::Socket::SslTcpServer
           ssl.accept_nonblock
 
         rescue ::IO::WaitReadable
-          IO::select( [ self.sslsock ], nil, nil, 0.10 )
+          IO::select( [ ssl ], nil, nil, 0.10 )
           retry
 
         rescue ::IO::WaitWritable
-          IO::select( nil, [ self.sslsock ], nil, 0.10 )
+          IO::select( nil, [ ssl ], nil, 0.10 )
           retry
         end
       end

--- a/spec/rex/socket/ssl_tcp_server_spec.rb
+++ b/spec/rex/socket/ssl_tcp_server_spec.rb
@@ -1,0 +1,121 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+require 'openssl'
+
+RSpec.describe Rex::Socket::SslTcpServer do
+  let(:loopback) { '127.0.0.1' }
+
+  def make_ssl_context
+    key  = OpenSSL::PKey::RSA.new(2048)
+    cert = OpenSSL::X509::Certificate.new.tap do |c|
+      c.version   = 2
+      c.serial    = 1
+      c.subject   = OpenSSL::X509::Name.parse('/CN=test')
+      c.issuer    = c.subject
+      c.public_key = key.public_key
+      c.not_before = Time.now - 1
+      c.not_after  = Time.now + 3600
+      c.sign(key, OpenSSL::Digest::SHA256.new)
+    end
+    ctx           = OpenSSL::SSL::SSLContext.new
+    ctx.key       = key
+    ctx.cert      = cert
+    ctx
+  end
+
+  def make_server(ctx = make_ssl_context)
+    described_class.create(
+      'LocalHost' => loopback,
+      'LocalPort' => 0,
+      'SSLContext' => ctx
+    )
+  end
+
+  def make_client(port, ctx = nil)
+    raw = TCPSocket.new(loopback, port)
+    client_ctx = OpenSSL::SSL::SSLContext.new
+    client_ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    ssl = OpenSSL::SSL::SSLSocket.new(raw, client_ctx)
+    ssl.connect
+    ssl
+  rescue => e
+    raw&.close
+    raise e
+  end
+
+  describe '#accept' do
+    it 'completes the TLS handshake and returns an SSL-wrapped socket' do
+      server = make_server
+      port   = server.local_address.ip_port
+
+      client_thread = Thread.new { make_client(port) }
+
+      accepted = server.accept
+      client   = client_thread.value
+
+      expect(accepted).not_to be_nil
+      expect(accepted).to respond_to(:sslsock)
+
+      client.write('hello')
+      expect(accepted.get_once).to eq('hello')
+    ensure
+      accepted&.close rescue nil
+      client&.close   rescue nil
+      server&.close   rescue nil
+    end
+
+    it 'accepts multiple sequential connections without raising NoMethodError' do
+      server = make_server
+      port   = server.local_address.ip_port
+
+      3.times do
+        client_thread = Thread.new { make_client(port) }
+        accepted = server.accept
+        client   = client_thread.value
+
+        expect(accepted).not_to be_nil
+        client.close   rescue nil
+        accepted.close rescue nil
+      end
+    ensure
+      server&.close rescue nil
+    end
+
+    it 'does not raise NoMethodError for sslsock during non-blocking TLS accept' do
+      # Regression test for the bug where accept_nonblock retry paths called
+      # self.sslsock (the server, which has no such method) instead of the
+      # ssl local variable (the SSLSocket being accepted).
+      server = make_server
+      port   = server.local_address.ip_port
+
+      client_thread = Thread.new { make_client(port) }
+
+      accepted = server.accept
+      expect(accepted).not_to be_nil
+
+      client = client_thread.value
+    ensure
+      accepted&.close rescue nil
+      client&.close   rescue nil
+      server&.close   rescue nil
+    end
+
+    it 'returns nil and does not raise when a client connects but aborts the TLS handshake' do
+      server = make_server
+      port   = server.local_address.ip_port
+
+      # Connect a raw TCP socket without doing TLS — the handshake will fail
+      client_thread = Thread.new do
+        raw = TCPSocket.new(loopback, port)
+        raw.close
+      end
+
+      result = server.accept
+      expect(result).to be_nil
+
+      client_thread.join
+    ensure
+      server&.close rescue nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/rapid7/rex-socket/commit/04b35d4085c7f8a621d41e50a5b1b6509b4f533e


### Before 🔴 

On windows the reverse https c2 malleable payload supports in 6.5 consistently failed:

```
[07/23/2026 10:32:19] [e(0)] core: Error in stream server server monitor: undefined method `sslsock' for #<Socket:0x000001b0e8493b90>

Call stack:
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/rex-socket-0.1.70/lib/rex/socket/ssl_tcp_server.rb:75:in `rescue in accept'
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/rex-socket-0.1.70/lib/rex/socket/ssl_tcp_server.rb:71:in `accept'
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/rex-core-0.1.36/lib/rex/io/stream_server.rb:142:in `monitor_listener'
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/rex-core-0.1.36/lib/rex/io/stream_server.rb:61:in `block in start'
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/bundler/gems/metasploit-framework-7e49ec9853e3/lib/rex/thread_factory.rb:22:in `block in spawn'
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/bundler/gems/metasploit-framework-7e49ec9853e3/lib/msf/core/thread_manager.rb:105:in `block in spawn'
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/logging-2.4.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
```

### After 🍏

no stack trace, and shells:

```
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[+] [2026.07.23-11:19:42] Workspace:MalleableCleanup Beginning step 1/1 Exploiting 10.140.10.238 - Progress: 0%
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] [2026.07.23-11:19:43] Started HTTPS reverse handler on https://10.140.110.21:4455/
[*] [2026.07.23-11:19:43] 10.140.10.238:445 - Connecting to the server...
[*] [2026.07.23-11:19:43] 10.140.10.238:445 - Authenticating to 10.140.10.238:445 as user 'vagrant'...
[*] [2026.07.23-11:19:43] 10.140.10.238:445 - Selecting PowerShell target
[*] [2026.07.23-11:19:43] 10.140.10.238:445 - Executing the payload...
[+] [2026.07.23-11:19:44] 10.140.10.238:445 - Service start timed out, OK if running a command or non-service executable...
[*] [2026.07.23-11:19:50] https://10.140.110.21:4455/ handling request from 10.140.10.238; (UUID: ho8a24yp) Staging x86 payload (203962 bytes) ...
[*] [2026.07.23-11:20:42] Complete (1 session opened) exploit/windows/smb/psexec
[+] [2026.07.23-11:20:42] Workspace:MalleableCleanup Task Completed - Progress: 100%
```

